### PR TITLE
Bschnurr/fix glb empty

### DIFF
--- a/GLTFSDK.Test/GLTFSDK.Test.vcxproj
+++ b/GLTFSDK.Test/GLTFSDK.Test.vcxproj
@@ -95,6 +95,7 @@
     <ClCompile Include="Source\AnimationUtilsTests.cpp" />
     <ClCompile Include="Source\ColorTests.cpp" />
     <ClCompile Include="Source\ExtrasDocumentTests.cpp" />
+    <ClCompile Include="Source\GLBResourceWriterTests.cpp" />
     <ClCompile Include="Source\GLTFExtensionsTests.cpp" />
     <ClCompile Include="Source\glTFPropertyTests.cpp" />
     <ClCompile Include="Source\GLTFResourceReaderTests.cpp" />

--- a/GLTFSDK.Test/GLTFSDK.Test.vcxproj.filters
+++ b/GLTFSDK.Test/GLTFSDK.Test.vcxproj.filters
@@ -89,6 +89,9 @@
     <ClCompile Include="Source\VersionTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Source\GLBResourceWriterTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\gltf\ReciprocatingSaw.gltf">

--- a/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
+++ b/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 
 #include "stdafx.h"
-
 #include <GLTFSDK/GLBResourceWriter.h>
-
 #include "TestUtils.h"
 
 using namespace glTF::UnitTest;
@@ -21,7 +19,7 @@ namespace Microsoft
                 {
                     auto streamWriter = std::make_shared<const StreamReaderWriter>();
                     GLBResourceWriter writer(streamWriter);
-                    std::string uri = "glb";
+                    std::string uri = "foo.glb";
 
                     writer.Flush("", uri);
                     auto stream = streamWriter->GetOutputStream(uri);

--- a/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
+++ b/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
@@ -3,6 +3,7 @@
 
 #include "stdafx.h"
 #include <GLTFSDK/GLBResourceWriter.h>
+#include <GLTFSDK/Serialize.h>
 #include "TestUtils.h"
 
 using namespace glTF::UnitTest;
@@ -21,7 +22,10 @@ namespace Microsoft
                     GLBResourceWriter writer(streamWriter);
                     std::string uri = "foo.glb";
 
-                    writer.Flush("", uri);
+                    Document doc;
+                    const auto defaultManifest = Serialize(doc, SerializeFlags::Pretty);
+
+                    writer.Flush(defaultManifest, uri);
                     auto stream = streamWriter->GetOutputStream(uri);
 
                     Assert::IsFalse(stream->fail());

--- a/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
+++ b/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "stdafx.h"
+
+#include <GLTFSDK/BufferBuilder.h>
+#include <GLTFSDK/Deserialize.h>
+#include <GLTFSDK/GLBResourceWriter.h>
+#include <GLTFSDK/Serialize.h>
+
+#include "TestUtils.h"
+
+using namespace glTF::UnitTest;
+
+namespace Microsoft
+{
+    namespace  glTF
+    {
+        namespace Test
+        {
+            GLTFSDK_TEST_CLASS(GLBResourceWriterTests)
+            {
+                GLTFSDK_TEST_METHOD(GLBResourceWriterTests, WriteBufferView_Empty)
+                {
+                    auto streamWriter = std::make_shared<const StreamReaderWriter>();
+                    GLBResourceWriter writer(streamWriter);
+                    std::string uri = "glb";
+                    writer.Flush("", uri);
+
+                    std::vector<char> output(100);
+                    writer.WriteExternal(uri, output);
+                }
+            };
+        }
+    }
+}

--- a/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
+++ b/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
@@ -12,7 +12,7 @@ using namespace glTF::UnitTest;
 
 namespace Microsoft
 {
-    namespace  glTF
+    namespace glTF
     {
         namespace Test
         {

--- a/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
+++ b/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
@@ -31,7 +31,7 @@ namespace Microsoft
                     auto stream = streamWriter->GetInputStream(uri);
 
                     // Deserialize Stream -> Document
-                    GLBResourceReader resourceReader(std::make_shared<const StreamReaderWriter>(), stream);
+                    GLBResourceReader resourceReader(streamWriter, stream);
                     Document roundTrippedDoc = Deserialize(resourceReader.GetJson());
 
                     Assert::IsFalse(stream->fail());

--- a/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
+++ b/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
@@ -3,10 +3,7 @@
 
 #include "stdafx.h"
 
-#include <GLTFSDK/BufferBuilder.h>
-#include <GLTFSDK/Deserialize.h>
 #include <GLTFSDK/GLBResourceWriter.h>
-#include <GLTFSDK/Serialize.h>
 
 #include "TestUtils.h"
 

--- a/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
+++ b/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
@@ -17,15 +17,16 @@ namespace Microsoft
         {
             GLTFSDK_TEST_CLASS(GLBResourceWriterTests)
             {
-                GLTFSDK_TEST_METHOD(GLBResourceWriterTests, WriteBufferView_Empty)
+                GLTFSDK_TEST_METHOD(GLBResourceWriterTests, WriteBufferView_Empty_Bin)
                 {
                     auto streamWriter = std::make_shared<const StreamReaderWriter>();
                     GLBResourceWriter writer(streamWriter);
                     std::string uri = "glb";
-                    writer.Flush("", uri);
 
-                    std::vector<char> output(100);
-                    writer.WriteExternal(uri, output);
+                    writer.Flush("", uri);
+                    auto stream = streamWriter->GetOutputStream(uri);
+
+                    Assert::IsFalse(stream->fail());
                 }
             };
         }

--- a/GLTFSDK/Source/GLBResourceWriter.cpp
+++ b/GLTFSDK/Source/GLBResourceWriter.cpp
@@ -84,7 +84,10 @@ void GLBResourceWriter::Flush(const std::string& manifest, const std::string& ur
     StreamUtils::WriteBinary(*stream, GLB_CHUNK_TYPE_BIN, GLB_CHUNK_TYPE_SIZE);
 
     // Write BIN contents (indeterminate length) - copy the temporary buffer's contents to the output stream
-    *stream << m_stream->rdbuf();
+    if (binaryChunkLength > 0)
+    {
+        *stream << m_stream->rdbuf();
+    }
 
     if (binaryPaddingLength > 0)
     {


### PR DESCRIPTION
Adding support to write out empty glb files. "stream" was going into a failed state with m_stream was empty.
