### PR TITLE
Updated copyright notice to comply with MS NuGet publishing

### DIFF
--- a/GLTFSDK/GLTFSDK.Android.CPP.nuspec
+++ b/GLTFSDK/GLTFSDK.Android.CPP.nuspec
@@ -8,7 +8,7 @@
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>A C++ library for decoding and encoding glTF files.</description>
-    <copyright>(C) Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
     <projectUrl>https://aka.ms/Y8fymc</projectUrl>
     <iconUrl>https://i.imgur.com/dj5ogtZ.png</iconUrl>

--- a/GLTFSDK/GLTFSDK.CPP.autopkg
+++ b/GLTFSDK/GLTFSDK.CPP.autopkg
@@ -8,7 +8,7 @@ nuget {
         requireLicenseAcceptance : true;
         summary : @"A C++ library for decoding and encoding glTF files.";
         description : @"A C++ library for decoding and encoding glTF files.";
-        copyright : @"(C) Microsoft Corporation. All rights reserved.";
+        copyright : @"© Microsoft Corporation. All rights reserved.";
         licenseUrl : "https://opensource.org/licenses/MIT";
         projectUrl : "https://aka.ms/Y8fymc";
         iconUrl : "https://i.imgur.com/dj5ogtZ.png";

--- a/GLTFSDK/GLTFSDK.Windows.CPP.autopkg
+++ b/GLTFSDK/GLTFSDK.Windows.CPP.autopkg
@@ -8,7 +8,7 @@ nuget {
         requireLicenseAcceptance : true;
         summary : @"A C++ library for decoding and encoding glTF files.";
         description : @"A C++ library for decoding and encoding glTF files.";
-        copyright : @"(C) Microsoft Corporation. All rights reserved.";
+        copyright : @"© Microsoft Corporation. All rights reserved.";
         licenseUrl : "https://opensource.org/licenses/MIT";
         projectUrl : "https://aka.ms/Y8fymc";
         iconUrl : "https://i.imgur.com/dj5ogtZ.png";

--- a/GLTFSDK/GLTFSDK.iOS.CPP.nuspec
+++ b/GLTFSDK/GLTFSDK.iOS.CPP.nuspec
@@ -8,7 +8,7 @@
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A C++ library for decoding and encoding glTF files.</description>
-    <copyright>(C) Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags></tags>
     <releaseNotes>(Replaced by NuGet build system)</releaseNotes>
         <dependencies>

--- a/GLTFSDK/GLTFSDK.macOS.CPP.nuspec
+++ b/GLTFSDK/GLTFSDK.macOS.CPP.nuspec
@@ -8,7 +8,7 @@
     <owners>Microsoft</owners>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>A C++ library for decoding and encoding glTF files.</description>
-    <copyright>(C) Microsoft Corporation. All rights reserved.</copyright>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <licenseUrl>https://opensource.org/licenses/MIT</licenseUrl>
     <projectUrl>https://aka.ms/Y8fymc</projectUrl>
     <iconUrl>https://i.imgur.com/dj5ogtZ.png</iconUrl>


### PR DESCRIPTION
Automated NuGet package validation via MS requires that the copyright notice be exact, which means we have to use the unicode '©' instead of '(c)'