### PR TITLE
Avoid duplicate target definitions for external projects

### DIFF
--- a/External/RapidJSON/CMakeLists.txt
+++ b/External/RapidJSON/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Check if the RapidJSON target has already been defined
+if (TARGET RapidJSON)
+  message(AUTHOR_WARNING "RapidJSON target already defined, skipping")
+  return()
+endif()
+
 # Download and unpack RapidJSON at configure time
 configure_file(CMakeRapidJSONDownload.txt.in ${CMAKE_BINARY_DIR}/RapidJSON-download/CMakeLists.txt)
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .

--- a/External/googletest/CMakeLists.txt
+++ b/External/googletest/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Check if the gtest target has already been defined
+if (TARGET gtest)
+  message(AUTHOR_WARNING "gtest target already defined, skipping")
+  return()
+endif()
+
 # Download and unpack googletest at configure time
 configure_file(CMakeGoogleTestDownload.txt.in ${CMAKE_BINARY_DIR}/googletest-download/CMakeLists.txt)
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .


### PR DESCRIPTION
If the target is already defined then don't download the external project.
This allows others who are using this project as an external project to define their own versions of these targets first.