### PR TITLE
Fix pdb install paths

### DIFF
--- a/Build/CMake/Modules/GLTFPlatform.cmake
+++ b/Build/CMake/Modules/GLTFPlatform.cmake
@@ -69,7 +69,7 @@ function(CreateGLTFInstallTargets target platform)
     )
 
     if (MSVC)
-        install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}/$<CONFIG>/${PROJECT_NAME}.pdb DESTINATION ${CMAKE_SOURCE_DIR}/Built/Out/${platform}/$<CONFIG>/${PROJECT_NAME})
+        install(FILES ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/${PROJECT_NAME}.pdb DESTINATION ${CMAKE_SOURCE_DIR}/Built/Out/${platform}/$<CONFIG>/${PROJECT_NAME})
     endif()
 
 endfunction(CreateGLTFInstallTargets)


### PR DESCRIPTION
Use ${CMAKE_CURRENT_BINARY_DIR} instead of ${CMAKE_BINARY_DIR}/${PROJECT_NAME}.
When building GLTFSDK as an external dependency of another build they may not be equivalent.