### PR TITLE
cmake - Switch to RapidJSON from https://github.com/Tencent/rapidjson…

### DIFF
--- a/External/RapidJSON/CMakeRapidJSONDownload.txt.in
+++ b/External/RapidJSON/CMakeRapidJSONDownload.txt.in
@@ -4,8 +4,8 @@ project(RapidJSON-download NONE)
 
 include(ExternalProject)
 ExternalProject_Add(RapidJSON
-  GIT_REPOSITORY    https://github.com/fergsatwork/rapidjson
-  GIT_TAG           631df504108378589c17ee7a1ff9b52790a537d8
+  GIT_REPOSITORY    https://github.com/Tencent/rapidjson.git
+  GIT_TAG           17ae6ffa857173c25708e61610121bc908c0a6cd
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/RapidJSON-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/RapidJSON-build"
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
….git

The only difference between this and the fergatwork version is the NuGet build files, which we don't need when using as an external dependency with cmake.
It is using the commit from which the fergsatwork repo was created.  The code is the same.