### PR TITLE
JUnit instead of xUnit

### DIFF
--- a/Build/AzureDevOps/azure-pipelines.yml
+++ b/Build/AzureDevOps/azure-pipelines.yml
@@ -31,7 +31,7 @@ jobs:
 
     - task: PublishTestResults@2
       inputs:
-        testResultsFormat: 'xUnit'
+        testResultsFormat: 'JUnit'
         testResultsFiles: built\Out\windows_$(buildPlatform)\$(buildConfiguration)\GLTFSDK.Test\GLTFSDK.Test.log
 
   - job: MacOS
@@ -61,7 +61,7 @@ jobs:
 
     - task: PublishTestResults@2
       inputs:
-        testResultsFormat: 'xUnit'
+        testResultsFormat: 'JUnit'
         testResultsFiles: built/Out/$(buildPlatform)/$(buildConfiguration)/GLTFSDK.Test/GLTFSDK.Test.log
 
   - job: iOS


### PR DESCRIPTION
Apparently googletest output more closely resembles JUnit than xUnit since Azure Pipeline wasn't able to parse it as xUnit.  This used to work, but it looks like maybe Azure DevOps updated to [xUnit2](https://xunit.github.io/docs/format-xml-v2.html) which is an entirely different schema than [xUnit](https://gist.github.com/erikd/4192748)