### PR TITLE
Remove Exception const char* constructors

### DIFF
--- a/GLTFSDK/Inc/GLTFSDK/Exceptions.h
+++ b/GLTFSDK/Inc/GLTFSDK/Exceptions.h
@@ -14,7 +14,7 @@ namespace Microsoft
         class GLTFException : public std::runtime_error
         {
         public:
-            GLTFException(const char* msg) : std::runtime_error(msg) {}
+            //GLTFException(const char* msg) : std::runtime_error(msg) {}
             GLTFException(const std::string& msg) : std::runtime_error(msg) {}
         };
 
@@ -22,7 +22,7 @@ namespace Microsoft
         class InvalidGLTFException : public GLTFException
         {
         public:
-            InvalidGLTFException(const char* msg) : GLTFException(msg) {}
+            //InvalidGLTFException(const char* msg) : GLTFException(msg) {}
             InvalidGLTFException(const std::string& msg) : GLTFException(msg) {}
         };
 
@@ -30,7 +30,7 @@ namespace Microsoft
         class DocumentException : public GLTFException
         {
         public:
-            DocumentException(const char* msg) : GLTFException(msg) {}
+            //DocumentException(const char* msg) : GLTFException(msg) {}
             DocumentException(const std::string& msg) : GLTFException(msg) {}
         };
 
@@ -38,7 +38,7 @@ namespace Microsoft
         class ValidationException : public GLTFException
         {
         public:
-            ValidationException(const char* msg) : GLTFException(msg) {}
+            //ValidationException(const char* msg) : GLTFException(msg) {}
             ValidationException(const std::string& msg) : GLTFException(msg) {}
         };
     }

--- a/GLTFSDK/Inc/GLTFSDK/Exceptions.h
+++ b/GLTFSDK/Inc/GLTFSDK/Exceptions.h
@@ -14,7 +14,6 @@ namespace Microsoft
         class GLTFException : public std::runtime_error
         {
         public:
-            //GLTFException(const char* msg) : std::runtime_error(msg) {}
             GLTFException(const std::string& msg) : std::runtime_error(msg) {}
         };
 
@@ -22,7 +21,6 @@ namespace Microsoft
         class InvalidGLTFException : public GLTFException
         {
         public:
-            //InvalidGLTFException(const char* msg) : GLTFException(msg) {}
             InvalidGLTFException(const std::string& msg) : GLTFException(msg) {}
         };
 
@@ -30,7 +28,6 @@ namespace Microsoft
         class DocumentException : public GLTFException
         {
         public:
-            //DocumentException(const char* msg) : GLTFException(msg) {}
             DocumentException(const std::string& msg) : GLTFException(msg) {}
         };
 
@@ -38,7 +35,6 @@ namespace Microsoft
         class ValidationException : public GLTFException
         {
         public:
-            //ValidationException(const char* msg) : GLTFException(msg) {}
             ValidationException(const std::string& msg) : GLTFException(msg) {}
         };
     }


### PR DESCRIPTION
Removes the const char* constructors from all the GLTFException derived types. Use of these constructors causes various unit tests to fail on the build machines (although these tests don't fail when run locally).