### PR TITLE
Update the Windows 10 SDK used by the samples projects

### DIFF
--- a/GLTFSDK.Samples/Deserialize/Deserialize.vcxproj
+++ b/GLTFSDK.Samples/Deserialize/Deserialize.vcxproj
@@ -39,7 +39,7 @@
     <ProjectGuid>{DE6A7757-2DF3-4705-829B-96A77BABF0B2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Deserialize</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/GLTFSDK.Samples/Serialize/Serialize.vcxproj
+++ b/GLTFSDK.Samples/Serialize/Serialize.vcxproj
@@ -39,7 +39,7 @@
     <ProjectGuid>{DE6A7757-2DE3-4705-829B-96A77BABF0B2}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Serialize</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">


### PR DESCRIPTION
Updating VS 2017 to 15.9.5 appears to uninstall the previous version of the SDK for ARM & ARM64 (10.0.15063.0) so use 10.0.16299.0 instead