### PR TITLE
Chriche/optional

### DIFF
--- a/GLTFSDK.Shared.CPP/GLTFSDK.Shared.CPP.vcxitems
+++ b/GLTFSDK.Shared.CPP/GLTFSDK.Shared.CPP.vcxitems
@@ -60,6 +60,7 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Inc\GLTFSDK\Math.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Inc\GLTFSDK\MeshPrimitiveUtils.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Inc\GLTFSDK\MicrosoftGeneratorVersion.h" />
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Inc\GLTFSDK\Optional.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Inc\GLTFSDK\PBRUtils.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Inc\GLTFSDK\RapidJsonUtils.h" />
     <ClInclude Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Inc\GLTFSDK\ResourceReaderUtils.h" />

--- a/GLTFSDK.Shared.CPP/GLTFSDK.Shared.CPP.vcxitems.filters
+++ b/GLTFSDK.Shared.CPP/GLTFSDK.Shared.CPP.vcxitems.filters
@@ -197,6 +197,9 @@
     <ClInclude Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Inc\GLTFSDK\SchemaValidation.h">
       <Filter>Header Files\GLTFSDK</Filter>
     </ClInclude>
+    <ClInclude Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Inc\GLTFSDK\Optional.h">
+      <Filter>Header Files\GLTFSDK</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)..\GLTFSDK\schema\accessor.schema.json">

--- a/GLTFSDK.Test/GLTFSDK.Test.vcxproj
+++ b/GLTFSDK.Test/GLTFSDK.Test.vcxproj
@@ -105,6 +105,7 @@
     <ClCompile Include="Source\IndexedContainerTests.cpp" />
     <ClCompile Include="Source\MeshPrimitiveUtilsTests.cpp" />
     <ClCompile Include="Source\MicrosoftGeneratorVersionTests.cpp" />
+    <ClCompile Include="Source\OptionalTests.cpp" />
     <ClCompile Include="Source\PBRUtilsTests.cpp" />
     <ClCompile Include="Source\ResourceReaderUtilsTests.cpp" />
     <ClCompile Include="Source\SerializeTests.cpp" />

--- a/GLTFSDK.Test/GLTFSDK.Test.vcxproj.filters
+++ b/GLTFSDK.Test/GLTFSDK.Test.vcxproj.filters
@@ -258,6 +258,8 @@
     <None Include="Resources\glTF-Asset-Generator\Mesh_PrimitiveMode\Mesh_PrimitiveMode_15.bin">
       <Filter>Resource Files</Filter>
     </None>
-    <None Include="Resources\gltf\TextureTransformTest.gltf" />
+    <None Include="Resources\gltf\TextureTransformTest.gltf">
+      <Filter>Resource Files</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/GLTFSDK.Test/GLTFSDK.Test.vcxproj.filters
+++ b/GLTFSDK.Test/GLTFSDK.Test.vcxproj.filters
@@ -92,6 +92,9 @@
     <ClCompile Include="Source\GLBResourceWriterTests.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="Source\OptionalTests.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\gltf\ReciprocatingSaw.gltf">
@@ -255,5 +258,6 @@
     <None Include="Resources\glTF-Asset-Generator\Mesh_PrimitiveMode\Mesh_PrimitiveMode_15.bin">
       <Filter>Resource Files</Filter>
     </None>
+    <None Include="Resources\gltf\TextureTransformTest.gltf" />
   </ItemGroup>
 </Project>

--- a/GLTFSDK.Test/Source/GLTFExtensionsTests.cpp
+++ b/GLTFSDK.Test/Source/GLTFExtensionsTests.cpp
@@ -429,7 +429,7 @@ namespace Microsoft
 
                     auto checkTextureInfo = [](
                         const Material& material, 
-                        const Vector2& offset, float rotation, const Vector2& scale, std::unique_ptr<size_t> texCoord)
+                        const Vector2& offset, float rotation, const Vector2& scale, Detail::Optional<size_t> texCoord = {})
                     {
                         auto& textureInfo = material.metallicRoughness.baseColorTexture;
 
@@ -441,19 +441,19 @@ namespace Microsoft
                         expectedTextureTransform.offset = offset;
                         expectedTextureTransform.scale = scale;
                         expectedTextureTransform.rotation = rotation;
-                        expectedTextureTransform.texCoord = std::move(texCoord);
+                        expectedTextureTransform.texCoord = texCoord;
 
                         Assert::IsTrue(textureTransform == expectedTextureTransform);
                     };
 
                     Assert::IsTrue(doc.materials.Size() == 9);
 
-                    checkTextureInfo(doc.materials[0], Vector2(0.5f, 0.0f), 0.0f, Vector2(1.0f, 1.0f), {}); // Note: texCoord not specified
-                    checkTextureInfo(doc.materials[1], Vector2(0.0f, 0.5f), 0.0f, Vector2(1.0f, 1.0f), {});
-                    checkTextureInfo(doc.materials[2], Vector2(0.5f, 0.5f), 0.0f, Vector2(1.0f, 1.0f), {});
-                    checkTextureInfo(doc.materials[3], Vector2(0.0f, 0.0f), 0.39269908169872415480783042290994f, Vector2(1.0f, 1.0f), {});
-                    checkTextureInfo(doc.materials[4], Vector2(0.0f, 0.0f), 0.0f, Vector2(1.5f, 1.5f), {});
-                    checkTextureInfo(doc.materials[5], Vector2(-0.2f, -0.1f), 0.3f, Vector2(1.5f, 1.5f), {});
+                    checkTextureInfo(doc.materials[0], Vector2(0.5f, 0.0f), 0.0f, Vector2(1.0f, 1.0f)); // Note: texCoord not specified
+                    checkTextureInfo(doc.materials[1], Vector2(0.0f, 0.5f), 0.0f, Vector2(1.0f, 1.0f));
+                    checkTextureInfo(doc.materials[2], Vector2(0.5f, 0.5f), 0.0f, Vector2(1.0f, 1.0f));
+                    checkTextureInfo(doc.materials[3], Vector2(0.0f, 0.0f), 0.39269908169872415480783042290994f, Vector2(1.0f, 1.0f));
+                    checkTextureInfo(doc.materials[4], Vector2(0.0f, 0.0f), 0.0f, Vector2(1.5f, 1.5f));
+                    checkTextureInfo(doc.materials[5], Vector2(-0.2f, -0.1f), 0.3f, Vector2(1.5f, 1.5f));
                 }
 
                 GLTFSDK_TEST_METHOD(ExtensionsTests, Extensions_Test_HasTextureTransformExtension_TexCoord)
@@ -464,7 +464,7 @@ namespace Microsoft
 
                     auto checkTextureInfo = [](
                         const Material& material,
-                        const Vector2& offset, float rotation, const Vector2& scale, std::unique_ptr<size_t> texCoord)
+                        const Vector2& offset, float rotation, const Vector2& scale, Detail::Optional<size_t> texCoord = {})
                     {
                         auto& textureInfo = material.metallicRoughness.baseColorTexture;
 
@@ -476,15 +476,15 @@ namespace Microsoft
                         expectedTextureTransform.offset = offset;
                         expectedTextureTransform.scale = scale;
                         expectedTextureTransform.rotation = rotation;
-                        expectedTextureTransform.texCoord = std::move(texCoord);
+                        expectedTextureTransform.texCoord = texCoord;
 
                         Assert::IsTrue(textureTransform == expectedTextureTransform);
                     };
 
                     Assert::IsTrue(doc.materials.Size() == 2);
 
-                    checkTextureInfo(doc.materials[0], Vector2(-0.2f, -0.1f), 0.3f, Vector2(1.5f, 1.5f), std::make_unique<size_t>(1234));
-                    checkTextureInfo(doc.materials[1], Vector2(-0.2f, -0.1f), 0.3f, Vector2(1.5f, 1.5f), {});
+                    checkTextureInfo(doc.materials[0], Vector2(-0.2f, -0.1f), 0.3f, Vector2(1.5f, 1.5f), 1234);
+                    checkTextureInfo(doc.materials[1], Vector2(-0.2f, -0.1f), 0.3f, Vector2(1.5f, 1.5f));
 
                     const auto extensionSerializer = KHR::GetKHRExtensionSerializer();
                     auto tt = Serialize(doc, extensionSerializer);

--- a/GLTFSDK.Test/Source/GLTFExtensionsTests.cpp
+++ b/GLTFSDK.Test/Source/GLTFExtensionsTests.cpp
@@ -429,7 +429,7 @@ namespace Microsoft
 
                     auto checkTextureInfo = [](
                         const Material& material, 
-                        const Vector2& offset, float rotation, const Vector2& scale, Detail::Optional<size_t> texCoord = {})
+                        const Vector2& offset, float rotation, const Vector2& scale, Optional<size_t> texCoord = {})
                     {
                         auto& textureInfo = material.metallicRoughness.baseColorTexture;
 
@@ -464,7 +464,7 @@ namespace Microsoft
 
                     auto checkTextureInfo = [](
                         const Material& material,
-                        const Vector2& offset, float rotation, const Vector2& scale, Detail::Optional<size_t> texCoord = {})
+                        const Vector2& offset, float rotation, const Vector2& scale, Optional<size_t> texCoord = {})
                     {
                         auto& textureInfo = material.metallicRoughness.baseColorTexture;
 

--- a/GLTFSDK.Test/Source/GLTFResourceWriterTests.cpp
+++ b/GLTFSDK.Test/Source/GLTFResourceWriterTests.cpp
@@ -254,7 +254,6 @@ namespace Microsoft
                     bufferView.bufferId = "0";
                     bufferView.byteOffset = 0;
                     bufferView.byteLength = data.size() * sizeof(uint32_t);
-                    bufferView.target = BufferViewTarget::UNKNOWN_BUFFER;
 
                     writer.Write(bufferView, data.data());
 
@@ -280,7 +279,6 @@ namespace Microsoft
                     bufferView.bufferId = "0";
                     bufferView.byteOffset = 0;
                     bufferView.byteLength = data.size() * sizeof(uint32_t);
-                    bufferView.target = BufferViewTarget::UNKNOWN_BUFFER;
 
                     writer.Write(bufferView, data.data());
 
@@ -306,7 +304,6 @@ namespace Microsoft
                     bufferView.bufferId = "0";
                     bufferView.byteOffset = 0;
                     bufferView.byteLength = data.size() * sizeof(uint32_t);
-                    bufferView.target = BufferViewTarget::UNKNOWN_BUFFER;
 
                     writer.Write(bufferView, data.data());
 
@@ -332,7 +329,6 @@ namespace Microsoft
                     bufferView.bufferId = "0";
                     bufferView.byteOffset = 0;
                     bufferView.byteLength = data1.size() * sizeof(uint32_t);
-                    bufferView.target = BufferViewTarget::UNKNOWN_BUFFER;
 
                     writer.Write(bufferView, data1.data());
 
@@ -361,7 +357,6 @@ namespace Microsoft
                     bufferView.bufferId = "0";
                     bufferView.byteOffset = 0;
                     bufferView.byteLength = data.size() * sizeof(float);
-                    bufferView.target = BufferViewTarget::UNKNOWN_BUFFER;
 
                     Accessor accessor;
                     accessor.id = "0";
@@ -399,7 +394,6 @@ namespace Microsoft
                     bufferView.bufferId = "0";
                     bufferView.byteOffset = 0;
                     bufferView.byteLength = data.size() * sizeof(float);
-                    bufferView.target = BufferViewTarget::UNKNOWN_BUFFER;
 
                     Accessor accessor;
                     accessor.id = "0";
@@ -435,7 +429,6 @@ namespace Microsoft
                     bufferView.bufferId = "0";
                     bufferView.byteOffset = 0;
                     bufferView.byteLength = data1.size() * sizeof(uint8_t);
-                    bufferView.target = BufferViewTarget::UNKNOWN_BUFFER;
 
                     Accessor accessor;
                     accessor.id = "0";
@@ -488,7 +481,6 @@ namespace Microsoft
                     bufferView.bufferId = "0";
                     bufferView.byteOffset = 0;
                     bufferView.byteLength = data1.size() * sizeof(uint8_t);
-                    bufferView.target = BufferViewTarget::UNKNOWN_BUFFER;
 
                     Accessor accessor;
                     accessor.id = "0";
@@ -535,7 +527,6 @@ namespace Microsoft
                     bufferView.bufferId = "0";
                     bufferView.byteOffset = 0;
                     bufferView.byteLength = data.size() * sizeof(uint32_t) + 1U;// Add an additional byte as the accessor's byteOffset is 1;
-                    bufferView.target = BufferViewTarget::UNKNOWN_BUFFER;
 
                     Accessor accessor;
                     accessor.id = "0";
@@ -563,7 +554,6 @@ namespace Microsoft
                     bufferView.bufferId = "0";
                     bufferView.byteOffset = 1U;
                     bufferView.byteLength = data.size() * sizeof(uint32_t) + 5U;// Add an additional 5 bytes as the bufferView and accessor's byteOffsets are 1 and 4 respectively;
-                    bufferView.target = BufferViewTarget::UNKNOWN_BUFFER;
 
                     Accessor accessor;
                     accessor.id = "0";

--- a/GLTFSDK.Test/Source/OptionalTests.cpp
+++ b/GLTFSDK.Test/Source/OptionalTests.cpp
@@ -359,6 +359,8 @@ namespace Microsoft
                         Assert::AreEqual("Assign", opt1.Get().c_str());
                     }
 
+
+// Disable warnings (clang only) about self move-assignment so it is possible to test that the Optional type works as expected in this situation
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wself-move"

--- a/GLTFSDK.Test/Source/OptionalTests.cpp
+++ b/GLTFSDK.Test/Source/OptionalTests.cpp
@@ -5,6 +5,8 @@
 
 #include <GLTFSDK/Optional.h>
 
+using namespace glTF::UnitTest;
+
 namespace Microsoft
 {
     namespace glTF
@@ -375,6 +377,92 @@ namespace Microsoft
                         Assert::IsTrue(opt.HasValue());
 
                         Assert::AreEqual("Init", opt.Get().c_str());
+                    }
+                }
+
+                GLTFSDK_TEST_METHOD(OptionalTests, EqualTo)
+                {
+                    // lhs and rhs have no value
+                    {
+                        Detail::Optional<long> opt1;
+                        Detail::Optional<long> opt2;
+
+                        Assert::IsTrue(opt1 == opt2);
+                    }
+
+                    // only lhs has a value
+                    {
+                        Detail::Optional<long> opt1(1L);
+                        Detail::Optional<long> opt2;
+
+                        Assert::IsFalse(opt1 == opt2);
+                    }
+
+                    // only rhs has a value
+                    {
+                        Detail::Optional<long> opt1;
+                        Detail::Optional<long> opt2(1L);
+
+                        Assert::IsFalse(opt1 == opt2);
+                    }
+
+                    // lhs and rhs have the same value
+                    {
+                        Detail::Optional<long> opt1(1L);
+                        Detail::Optional<long> opt2(1L);
+
+                        Assert::IsTrue(opt1 == opt2);
+                    }
+
+                    // lhs and rhs have different values
+                    {
+                        Detail::Optional<long> opt1(1L);
+                        Detail::Optional<long> opt2(2L);
+
+                        Assert::IsFalse(opt1 == opt2);
+                    }
+                }
+
+                GLTFSDK_TEST_METHOD(OptionalTests, NotEqualTo)
+                {
+                    // lhs and rhs have no value
+                    {
+                        Detail::Optional<long> opt1;
+                        Detail::Optional<long> opt2;
+
+                        Assert::IsFalse(opt1 != opt2);
+                    }
+
+                    // only lhs has a value
+                    {
+                        Detail::Optional<long> opt1(1L);
+                        Detail::Optional<long> opt2;
+
+                        Assert::IsTrue(opt1 != opt2);
+                    }
+
+                    // only rhs has a value
+                    {
+                        Detail::Optional<long> opt1;
+                        Detail::Optional<long> opt2(1L);
+
+                        Assert::IsTrue(opt1 != opt2);
+                    }
+
+                    // lhs and rhs have the same value
+                    {
+                        Detail::Optional<long> opt1(1L);
+                        Detail::Optional<long> opt2(1L);
+
+                        Assert::IsFalse(opt1 != opt2);
+                    }
+
+                    // lhs and rhs have different values
+                    {
+                        Detail::Optional<long> opt1(1L);
+                        Detail::Optional<long> opt2(2L);
+
+                        Assert::IsTrue(opt1 != opt2);
                     }
                 }
             };

--- a/GLTFSDK.Test/Source/OptionalTests.cpp
+++ b/GLTFSDK.Test/Source/OptionalTests.cpp
@@ -1,0 +1,383 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "stdafx.h"
+
+#include <GLTFSDK/Optional.h>
+
+namespace Microsoft
+{
+    namespace glTF
+    {
+        namespace Test
+        {
+            GLTFSDK_TEST_CLASS(OptionalTests)
+            {
+                GLTFSDK_TEST_METHOD(OptionalTests, ConstructorDefault)
+                {
+                    Detail::Optional<int> optional;
+
+                    Assert::IsFalse(static_cast<bool>(optional));
+                    Assert::IsFalse(optional.HasValue());
+
+                    Assert::ExpectException<GLTFException>([&optional]{ optional.Get(); });
+                }
+
+                GLTFSDK_TEST_METHOD(OptionalTests, ConstructorValueCopy)
+                {
+                    Detail::Optional<double> optional(1.0);
+
+                    Assert::IsTrue(static_cast<bool>(optional));
+                    Assert::IsTrue(optional.HasValue());
+
+                    Assert::AreEqual(1.0, optional.Get());
+                }
+
+                GLTFSDK_TEST_METHOD(OptionalTests, ConstructorValueMove)
+                {
+                    Detail::Optional<std::unique_ptr<int>> optional(std::make_unique<int>(1));
+
+                    Assert::IsTrue(static_cast<bool>(optional));
+                    Assert::IsTrue(optional.HasValue());
+
+                    Assert::AreEqual(1, *optional.Get().get());
+                }
+
+                GLTFSDK_TEST_METHOD(OptionalTests, ConstructorOptionalCopy)
+                {
+                    Detail::Optional<unsigned int> opt1;
+                    Detail::Optional<unsigned int> opt2(opt1);
+                    Detail::Optional<unsigned int> opt3(3U);
+                    Detail::Optional<unsigned int> opt4(opt3);
+
+                    Assert::IsFalse(static_cast<bool>(opt1));
+                    Assert::IsFalse(opt1.HasValue());
+
+                    Assert::IsFalse(static_cast<bool>(opt2));
+                    Assert::IsFalse(opt2.HasValue());
+
+                    Assert::IsTrue(static_cast<bool>(opt3));
+                    Assert::IsTrue(opt3.HasValue());
+
+                    Assert::IsTrue(static_cast<bool>(opt4));
+                    Assert::IsTrue(opt4.HasValue());
+
+                    Assert::ExpectException<GLTFException>([&opt1] { opt1.Get(); });
+                    Assert::ExpectException<GLTFException>([&opt2] { opt2.Get(); });
+
+                    Assert::AreEqual(3U, opt3.Get());
+                    Assert::AreEqual(3U, opt4.Get());
+                }
+
+                GLTFSDK_TEST_METHOD(OptionalTests, ConstructorOptionalMove)
+                {
+                    Detail::Optional<std::unique_ptr<int>> opt1;
+                    Detail::Optional<std::unique_ptr<int>> opt2(std::move(opt1));
+                    Detail::Optional<std::unique_ptr<int>> opt3(std::make_unique<int>(3));
+                    Detail::Optional<std::unique_ptr<int>> opt4(std::move(opt3));
+
+                    Assert::IsFalse(static_cast<bool>(opt1));
+                    Assert::IsFalse(opt1.HasValue());
+
+                    Assert::IsFalse(static_cast<bool>(opt2));
+                    Assert::IsFalse(opt2.HasValue());
+
+                    Assert::IsFalse(static_cast<bool>(opt3));
+                    Assert::IsFalse(opt3.HasValue());
+
+                    Assert::IsTrue(static_cast<bool>(opt4));
+                    Assert::IsTrue(opt4.HasValue());
+
+                    Assert::ExpectException<GLTFException>([&opt1] { opt1.Get(); });
+                    Assert::ExpectException<GLTFException>([&opt2] { opt2.Get(); });
+                    Assert::ExpectException<GLTFException>([&opt3] { opt3.Get(); });
+
+                    Assert::AreEqual(3, *opt4.Get().get());
+                }
+
+                GLTFSDK_TEST_METHOD(OptionalTests, DestructorReset)
+                {
+                    unsigned int count = 0U;
+
+                    struct Counter
+                    {
+                        Counter(unsigned int* count_ptr) : count_ptr(count_ptr)
+                        {
+                            ++(*count_ptr);
+                        }
+
+                        Counter(Counter&& other) : count_ptr(other.count_ptr)
+                        {
+                            ++(*count_ptr);
+                        }
+
+                        Counter(const Counter& other) : count_ptr(other.count_ptr)
+                        {
+                            ++(*count_ptr);
+                        }
+
+                        ~Counter()
+                        {
+                            --(*count_ptr);
+                        }
+
+                        unsigned int* count_ptr;
+                    };
+
+                    {
+                        Detail::Optional<Counter> opt1(&count);
+
+                        {
+                            Assert::AreEqual(1U, count);
+                            Detail::Optional<Counter> opt2(&count);
+                            Assert::AreEqual(2U, count);
+                        }
+
+                        Assert::AreEqual(1U, count);
+                        opt1.Reset();
+                        Assert::AreEqual(0U, count);
+                    }
+
+                    Assert::AreEqual(0U, count);
+                }
+
+                GLTFSDK_TEST_METHOD(OptionalTests, Swap)
+                {
+                    // Both lhs and rhs Optionals have values
+                    {
+                        Detail::Optional<char> optA('A');
+                        Detail::Optional<char> optB('B');
+
+                        Assert::AreEqual('A', optA.Get());
+                        Assert::AreEqual('B', optB.Get());
+
+                        Detail::Optional<char>::Swap(optA, optB); // After swapping optA should contain 'B' and optB should contain 'A'
+
+                        Assert::AreEqual('B', optA.Get());
+                        Assert::AreEqual('A', optB.Get());
+                    }
+
+                    // Only lhs Optional has a value
+                    {
+                        Detail::Optional<char> optA('A');
+                        Detail::Optional<char> optB;
+
+                        Assert::AreEqual('A', optA.Get());
+                        Assert::IsFalse(optB.HasValue());
+
+                        Detail::Optional<char>::Swap(optA, optB); // After swapping optA should be empty and optB should contain 'A'
+
+                        Assert::IsFalse(optA.HasValue());
+                        Assert::AreEqual('A', optB.Get());
+                    }
+
+                    // Only rhs Optional has a value
+                    {
+                        Detail::Optional<char> optA;
+                        Detail::Optional<char> optB('B');
+
+                        Assert::IsFalse(optA.HasValue());
+                        Assert::AreEqual('B', optB.Get());
+
+                        Detail::Optional<char>::Swap(optA, optB); // After swapping optA should contain 'B' and optB should be empty
+
+                        Assert::AreEqual('B', optA.Get());
+                        Assert::IsFalse(optB.HasValue());
+                    }
+                }
+
+                GLTFSDK_TEST_METHOD(OptionalTests, AssignmentValueCopy)
+                {
+                    const std::string assignValue("Assign");
+
+                    // Test assignment when Optional has no existing value
+                    {
+                        Detail::Optional<std::string> opt;
+
+                        Assert::IsFalse(opt.HasValue());
+                        opt = assignValue;
+                        Assert::IsTrue(opt.HasValue());
+
+                        Assert::AreEqual("Assign", opt.Get().c_str());
+                    }
+
+                    // Test assignment when Optional has an existing value
+                    {
+                        Detail::Optional<std::string> opt("Init");
+
+                        Assert::IsTrue(opt.HasValue());
+                        opt = assignValue;
+                        Assert::IsTrue(opt.HasValue());
+
+                        Assert::AreEqual("Assign", opt.Get().c_str());
+                    }
+                }
+
+                GLTFSDK_TEST_METHOD(OptionalTests, AssignmentValueMove)
+                {
+                    // Test assignment when Optional has no existing value
+                    {
+                        Detail::Optional<std::string> opt;
+
+                        Assert::IsFalse(opt.HasValue());
+                        opt = std::string("Assign");
+                        Assert::IsTrue(opt.HasValue());
+
+                        Assert::AreEqual("Assign", opt.Get().c_str());
+                    }
+
+                    // Test assignment when Optional has an existing value
+                    {
+                        Detail::Optional<std::string> opt("Init");
+
+                        Assert::IsTrue(opt.HasValue());
+                        opt = std::string("Assign");
+                        Assert::IsTrue(opt.HasValue());
+
+                        Assert::AreEqual("Assign", opt.Get().c_str());
+                    }
+                }
+
+                GLTFSDK_TEST_METHOD(OptionalTests, AssignmentOptionalCopy)
+                {
+                    // Test assignment when Optional has no existing value
+                    {
+                        Detail::Optional<std::string> opt1;
+                        Detail::Optional<std::string> opt2("Assign");
+
+                        Assert::IsFalse(opt1.HasValue());
+                        Assert::IsTrue(opt2.HasValue());
+
+                        opt1 = opt2;
+
+                        Assert::IsTrue(opt1.HasValue());
+                        Assert::IsTrue(opt2.HasValue());
+
+                        Assert::AreEqual("Assign", opt1.Get().c_str());
+                        Assert::AreEqual("Assign", opt2.Get().c_str());
+                    }
+
+                    // Test assignment when Optional has an existing value - assign no value
+                    {
+                        Detail::Optional<std::string> opt1("Init");
+                        Detail::Optional<std::string> opt2;
+
+                        Assert::IsTrue(opt1.HasValue());
+                        Assert::IsFalse(opt2.HasValue());
+
+                        opt1 = opt2;
+
+                        Assert::IsFalse(opt1.HasValue());
+                        Assert::IsFalse(opt2.HasValue());
+                    }
+
+                    // Test assignment when Optional has an existing value
+                    {
+                        Detail::Optional<std::string> opt1("Init");
+                        Detail::Optional<std::string> opt2("Assign");
+
+                        Assert::IsTrue(opt1.HasValue());
+                        Assert::IsTrue(opt2.HasValue());
+
+                        opt1 = opt2;
+
+                        Assert::IsTrue(opt1.HasValue());
+                        Assert::IsTrue(opt2.HasValue());
+
+                        Assert::AreEqual("Assign", opt1.Get().c_str());
+                        Assert::AreEqual("Assign", opt2.Get().c_str());
+                    }
+
+                    // Test self-assignment with no existing value
+                    {
+                        Detail::Optional<std::string> opt;
+
+                        Assert::IsFalse(opt.HasValue());
+                        opt = opt;
+                        Assert::IsFalse(opt.HasValue());
+                    }
+
+                    // Test self-assignment with an existing value
+                    {
+                        Detail::Optional<std::string> opt("Init");
+
+                        Assert::IsTrue(opt.HasValue());
+                        opt = opt;
+                        Assert::IsTrue(opt.HasValue());
+
+                        Assert::AreEqual("Init", opt.Get().c_str());
+                    }
+                }
+
+                GLTFSDK_TEST_METHOD(OptionalTests, AssignmentOptionalMove)
+                {
+                    // Test assignment when Optional has no existing value
+                    {
+                        Detail::Optional<std::string> opt1;
+                        Detail::Optional<std::string> opt2("Assign");
+
+                        Assert::IsFalse(opt1.HasValue());
+                        Assert::IsTrue(opt2.HasValue());
+
+                        opt1 = std::move(opt2);
+
+                        Assert::IsTrue(opt1.HasValue());
+                        Assert::IsFalse(opt2.HasValue());
+
+                        Assert::AreEqual("Assign", opt1.Get().c_str());
+                    }
+
+                    // Test assignment when Optional has an existing value - assign no value
+                    {
+                        Detail::Optional<std::string> opt1("Init");
+                        Detail::Optional<std::string> opt2;
+
+                        Assert::IsTrue(opt1.HasValue());
+                        Assert::IsFalse(opt2.HasValue());
+
+                        opt1 = std::move(opt2);
+
+                        Assert::IsFalse(opt1.HasValue());
+                        Assert::IsFalse(opt2.HasValue());
+                    }
+
+                    // Test assignment when Optional has an existing value
+                    {
+                        Detail::Optional<std::string> opt1("Init");
+                        Detail::Optional<std::string> opt2("Assign");
+
+                        Assert::IsTrue(opt1.HasValue());
+                        Assert::IsTrue(opt2.HasValue());
+
+                        opt1 = std::move(opt2);
+
+                        Assert::IsTrue(opt1.HasValue());
+                        Assert::IsFalse(opt2.HasValue());
+
+                        Assert::AreEqual("Assign", opt1.Get().c_str());
+                    }
+
+                    // Test self-assignment with no existing value
+                    {
+                        Detail::Optional<std::string> opt;
+
+                        Assert::IsFalse(opt.HasValue());
+                        opt = std::move(opt);
+                        Assert::IsFalse(opt.HasValue());
+                    }
+
+                    // Test self-assignment with an existing value
+                    {
+                        Detail::Optional<std::string> opt("Init");
+
+                        Assert::IsTrue(opt.HasValue());
+                        opt = std::move(opt);
+                        Assert::IsTrue(opt.HasValue());
+
+                        Assert::AreEqual("Init", opt.Get().c_str());
+                    }
+                }
+            };
+        }
+    }
+}

--- a/GLTFSDK.Test/Source/OptionalTests.cpp
+++ b/GLTFSDK.Test/Source/OptionalTests.cpp
@@ -359,6 +359,10 @@ namespace Microsoft
                         Assert::AreEqual("Assign", opt1.Get().c_str());
                     }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-move"
+#endif
                     // Test self-assignment with no existing value
                     {
                         Detail::Optional<std::string> opt;
@@ -378,6 +382,9 @@ namespace Microsoft
 
                         Assert::AreEqual("Init", opt.Get().c_str());
                     }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
                 }
 
                 GLTFSDK_TEST_METHOD(OptionalTests, EqualTo)

--- a/GLTFSDK.Test/Source/OptionalTests.cpp
+++ b/GLTFSDK.Test/Source/OptionalTests.cpp
@@ -17,7 +17,7 @@ namespace Microsoft
             {
                 GLTFSDK_TEST_METHOD(OptionalTests, ConstructorDefault)
                 {
-                    Detail::Optional<int> optional;
+                    Optional<int> optional;
 
                     Assert::IsFalse(static_cast<bool>(optional));
                     Assert::IsFalse(optional.HasValue());
@@ -27,7 +27,7 @@ namespace Microsoft
 
                 GLTFSDK_TEST_METHOD(OptionalTests, ConstructorValueCopy)
                 {
-                    Detail::Optional<double> optional(1.0);
+                    Optional<double> optional(1.0);
 
                     Assert::IsTrue(static_cast<bool>(optional));
                     Assert::IsTrue(optional.HasValue());
@@ -37,7 +37,7 @@ namespace Microsoft
 
                 GLTFSDK_TEST_METHOD(OptionalTests, ConstructorValueMove)
                 {
-                    Detail::Optional<std::unique_ptr<int>> optional(std::make_unique<int>(1));
+                    Optional<std::unique_ptr<int>> optional(std::make_unique<int>(1));
 
                     Assert::IsTrue(static_cast<bool>(optional));
                     Assert::IsTrue(optional.HasValue());
@@ -47,10 +47,10 @@ namespace Microsoft
 
                 GLTFSDK_TEST_METHOD(OptionalTests, ConstructorOptionalCopy)
                 {
-                    Detail::Optional<unsigned int> opt1;
-                    Detail::Optional<unsigned int> opt2(opt1);
-                    Detail::Optional<unsigned int> opt3(3U);
-                    Detail::Optional<unsigned int> opt4(opt3);
+                    Optional<unsigned int> opt1;
+                    Optional<unsigned int> opt2(opt1);
+                    Optional<unsigned int> opt3(3U);
+                    Optional<unsigned int> opt4(opt3);
 
                     Assert::IsFalse(static_cast<bool>(opt1));
                     Assert::IsFalse(opt1.HasValue());
@@ -73,10 +73,10 @@ namespace Microsoft
 
                 GLTFSDK_TEST_METHOD(OptionalTests, ConstructorOptionalMove)
                 {
-                    Detail::Optional<std::unique_ptr<int>> opt1;
-                    Detail::Optional<std::unique_ptr<int>> opt2(std::move(opt1));
-                    Detail::Optional<std::unique_ptr<int>> opt3(std::make_unique<int>(3));
-                    Detail::Optional<std::unique_ptr<int>> opt4(std::move(opt3));
+                    Optional<std::unique_ptr<int>> opt1;
+                    Optional<std::unique_ptr<int>> opt2(std::move(opt1));
+                    Optional<std::unique_ptr<int>> opt3(std::make_unique<int>(3));
+                    Optional<std::unique_ptr<int>> opt4(std::move(opt3));
 
                     Assert::IsFalse(static_cast<bool>(opt1));
                     Assert::IsFalse(opt1.HasValue());
@@ -127,11 +127,11 @@ namespace Microsoft
                     };
 
                     {
-                        Detail::Optional<Counter> opt1(&count);
+                        Optional<Counter> opt1(&count);
 
                         {
                             Assert::AreEqual(1U, count);
-                            Detail::Optional<Counter> opt2(&count);
+                            Optional<Counter> opt2(&count);
                             Assert::AreEqual(2U, count);
                         }
 
@@ -147,13 +147,13 @@ namespace Microsoft
                 {
                     // Both lhs and rhs Optionals have values
                     {
-                        Detail::Optional<char> optA('A');
-                        Detail::Optional<char> optB('B');
+                        Optional<char> optA('A');
+                        Optional<char> optB('B');
 
                         Assert::AreEqual('A', optA.Get());
                         Assert::AreEqual('B', optB.Get());
 
-                        Detail::Optional<char>::Swap(optA, optB); // After swapping optA should contain 'B' and optB should contain 'A'
+                        Optional<char>::Swap(optA, optB); // After swapping optA should contain 'B' and optB should contain 'A'
 
                         Assert::AreEqual('B', optA.Get());
                         Assert::AreEqual('A', optB.Get());
@@ -161,13 +161,13 @@ namespace Microsoft
 
                     // Only lhs Optional has a value
                     {
-                        Detail::Optional<char> optA('A');
-                        Detail::Optional<char> optB;
+                        Optional<char> optA('A');
+                        Optional<char> optB;
 
                         Assert::AreEqual('A', optA.Get());
                         Assert::IsFalse(optB.HasValue());
 
-                        Detail::Optional<char>::Swap(optA, optB); // After swapping optA should be empty and optB should contain 'A'
+                        Optional<char>::Swap(optA, optB); // After swapping optA should be empty and optB should contain 'A'
 
                         Assert::IsFalse(optA.HasValue());
                         Assert::AreEqual('A', optB.Get());
@@ -175,13 +175,13 @@ namespace Microsoft
 
                     // Only rhs Optional has a value
                     {
-                        Detail::Optional<char> optA;
-                        Detail::Optional<char> optB('B');
+                        Optional<char> optA;
+                        Optional<char> optB('B');
 
                         Assert::IsFalse(optA.HasValue());
                         Assert::AreEqual('B', optB.Get());
 
-                        Detail::Optional<char>::Swap(optA, optB); // After swapping optA should contain 'B' and optB should be empty
+                        Optional<char>::Swap(optA, optB); // After swapping optA should contain 'B' and optB should be empty
 
                         Assert::AreEqual('B', optA.Get());
                         Assert::IsFalse(optB.HasValue());
@@ -194,7 +194,7 @@ namespace Microsoft
 
                     // Test assignment when Optional has no existing value
                     {
-                        Detail::Optional<std::string> opt;
+                        Optional<std::string> opt;
 
                         Assert::IsFalse(opt.HasValue());
                         opt = assignValue;
@@ -205,7 +205,7 @@ namespace Microsoft
 
                     // Test assignment when Optional has an existing value
                     {
-                        Detail::Optional<std::string> opt("Init");
+                        Optional<std::string> opt("Init");
 
                         Assert::IsTrue(opt.HasValue());
                         opt = assignValue;
@@ -219,7 +219,7 @@ namespace Microsoft
                 {
                     // Test assignment when Optional has no existing value
                     {
-                        Detail::Optional<std::string> opt;
+                        Optional<std::string> opt;
 
                         Assert::IsFalse(opt.HasValue());
                         opt = std::string("Assign");
@@ -230,7 +230,7 @@ namespace Microsoft
 
                     // Test assignment when Optional has an existing value
                     {
-                        Detail::Optional<std::string> opt("Init");
+                        Optional<std::string> opt("Init");
 
                         Assert::IsTrue(opt.HasValue());
                         opt = std::string("Assign");
@@ -244,8 +244,8 @@ namespace Microsoft
                 {
                     // Test assignment when Optional has no existing value
                     {
-                        Detail::Optional<std::string> opt1;
-                        Detail::Optional<std::string> opt2("Assign");
+                        Optional<std::string> opt1;
+                        Optional<std::string> opt2("Assign");
 
                         Assert::IsFalse(opt1.HasValue());
                         Assert::IsTrue(opt2.HasValue());
@@ -261,8 +261,8 @@ namespace Microsoft
 
                     // Test assignment when Optional has an existing value - assign no value
                     {
-                        Detail::Optional<std::string> opt1("Init");
-                        Detail::Optional<std::string> opt2;
+                        Optional<std::string> opt1("Init");
+                        Optional<std::string> opt2;
 
                         Assert::IsTrue(opt1.HasValue());
                         Assert::IsFalse(opt2.HasValue());
@@ -275,8 +275,8 @@ namespace Microsoft
 
                     // Test assignment when Optional has an existing value
                     {
-                        Detail::Optional<std::string> opt1("Init");
-                        Detail::Optional<std::string> opt2("Assign");
+                        Optional<std::string> opt1("Init");
+                        Optional<std::string> opt2("Assign");
 
                         Assert::IsTrue(opt1.HasValue());
                         Assert::IsTrue(opt2.HasValue());
@@ -292,7 +292,7 @@ namespace Microsoft
 
                     // Test self-assignment with no existing value
                     {
-                        Detail::Optional<std::string> opt;
+                        Optional<std::string> opt;
 
                         Assert::IsFalse(opt.HasValue());
                         opt = opt;
@@ -301,7 +301,7 @@ namespace Microsoft
 
                     // Test self-assignment with an existing value
                     {
-                        Detail::Optional<std::string> opt("Init");
+                        Optional<std::string> opt("Init");
 
                         Assert::IsTrue(opt.HasValue());
                         opt = opt;
@@ -315,8 +315,8 @@ namespace Microsoft
                 {
                     // Test assignment when Optional has no existing value
                     {
-                        Detail::Optional<std::string> opt1;
-                        Detail::Optional<std::string> opt2("Assign");
+                        Optional<std::string> opt1;
+                        Optional<std::string> opt2("Assign");
 
                         Assert::IsFalse(opt1.HasValue());
                         Assert::IsTrue(opt2.HasValue());
@@ -331,8 +331,8 @@ namespace Microsoft
 
                     // Test assignment when Optional has an existing value - assign no value
                     {
-                        Detail::Optional<std::string> opt1("Init");
-                        Detail::Optional<std::string> opt2;
+                        Optional<std::string> opt1("Init");
+                        Optional<std::string> opt2;
 
                         Assert::IsTrue(opt1.HasValue());
                         Assert::IsFalse(opt2.HasValue());
@@ -345,8 +345,8 @@ namespace Microsoft
 
                     // Test assignment when Optional has an existing value
                     {
-                        Detail::Optional<std::string> opt1("Init");
-                        Detail::Optional<std::string> opt2("Assign");
+                        Optional<std::string> opt1("Init");
+                        Optional<std::string> opt2("Assign");
 
                         Assert::IsTrue(opt1.HasValue());
                         Assert::IsTrue(opt2.HasValue());
@@ -365,7 +365,7 @@ namespace Microsoft
 #endif
                     // Test self-assignment with no existing value
                     {
-                        Detail::Optional<std::string> opt;
+                        Optional<std::string> opt;
 
                         Assert::IsFalse(opt.HasValue());
                         opt = std::move(opt);
@@ -374,7 +374,7 @@ namespace Microsoft
 
                     // Test self-assignment with an existing value
                     {
-                        Detail::Optional<std::string> opt("Init");
+                        Optional<std::string> opt("Init");
 
                         Assert::IsTrue(opt.HasValue());
                         opt = std::move(opt);
@@ -391,40 +391,40 @@ namespace Microsoft
                 {
                     // lhs and rhs have no value
                     {
-                        Detail::Optional<long> opt1;
-                        Detail::Optional<long> opt2;
+                        Optional<long> opt1;
+                        Optional<long> opt2;
 
                         Assert::IsTrue(opt1 == opt2);
                     }
 
                     // only lhs has a value
                     {
-                        Detail::Optional<long> opt1(1L);
-                        Detail::Optional<long> opt2;
+                        Optional<long> opt1(1L);
+                        Optional<long> opt2;
 
                         Assert::IsFalse(opt1 == opt2);
                     }
 
                     // only rhs has a value
                     {
-                        Detail::Optional<long> opt1;
-                        Detail::Optional<long> opt2(1L);
+                        Optional<long> opt1;
+                        Optional<long> opt2(1L);
 
                         Assert::IsFalse(opt1 == opt2);
                     }
 
                     // lhs and rhs have the same value
                     {
-                        Detail::Optional<long> opt1(1L);
-                        Detail::Optional<long> opt2(1L);
+                        Optional<long> opt1(1L);
+                        Optional<long> opt2(1L);
 
                         Assert::IsTrue(opt1 == opt2);
                     }
 
                     // lhs and rhs have different values
                     {
-                        Detail::Optional<long> opt1(1L);
-                        Detail::Optional<long> opt2(2L);
+                        Optional<long> opt1(1L);
+                        Optional<long> opt2(2L);
 
                         Assert::IsFalse(opt1 == opt2);
                     }
@@ -434,40 +434,40 @@ namespace Microsoft
                 {
                     // lhs and rhs have no value
                     {
-                        Detail::Optional<long> opt1;
-                        Detail::Optional<long> opt2;
+                        Optional<long> opt1;
+                        Optional<long> opt2;
 
                         Assert::IsFalse(opt1 != opt2);
                     }
 
                     // only lhs has a value
                     {
-                        Detail::Optional<long> opt1(1L);
-                        Detail::Optional<long> opt2;
+                        Optional<long> opt1(1L);
+                        Optional<long> opt2;
 
                         Assert::IsTrue(opt1 != opt2);
                     }
 
                     // only rhs has a value
                     {
-                        Detail::Optional<long> opt1;
-                        Detail::Optional<long> opt2(1L);
+                        Optional<long> opt1;
+                        Optional<long> opt2(1L);
 
                         Assert::IsTrue(opt1 != opt2);
                     }
 
                     // lhs and rhs have the same value
                     {
-                        Detail::Optional<long> opt1(1L);
-                        Detail::Optional<long> opt2(1L);
+                        Optional<long> opt1(1L);
+                        Optional<long> opt2(1L);
 
                         Assert::IsFalse(opt1 != opt2);
                     }
 
                     // lhs and rhs have different values
                     {
-                        Detail::Optional<long> opt1(1L);
-                        Detail::Optional<long> opt2(2L);
+                        Optional<long> opt1(1L);
+                        Optional<long> opt2(2L);
 
                         Assert::IsTrue(opt1 != opt2);
                     }

--- a/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
+++ b/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
@@ -46,11 +46,11 @@ namespace Microsoft
 
             const Buffer& AddBuffer(const char* bufferId = nullptr);
 
-            const BufferView& AddBufferView(Detail::Optional<BufferViewTarget> target);
-            const BufferView& AddBufferView(const void* data, size_t byteLength, Detail::Optional<size_t> byteStride = {}, Detail::Optional<BufferViewTarget> target = {});
+            const BufferView& AddBufferView(Optional<BufferViewTarget> target);
+            const BufferView& AddBufferView(const void* data, size_t byteLength, Optional<size_t> byteStride = {}, Optional<BufferViewTarget> target = {});
 
             template<typename T>
-            const BufferView& AddBufferView(const std::vector<T>& data, Detail::Optional<size_t> byteStride = {}, Detail::Optional<BufferViewTarget> target = {})
+            const BufferView& AddBufferView(const std::vector<T>& data, Optional<size_t> byteStride = {}, Optional<BufferViewTarget> target = {})
             {
                 return AddBufferView(data.data(), data.size() * sizeof(T), byteStride, target);
             }

--- a/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
+++ b/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
@@ -46,11 +46,11 @@ namespace Microsoft
 
             const Buffer& AddBuffer(const char* bufferId = nullptr);
 
-            const BufferView& AddBufferView(BufferViewTarget target);
-            const BufferView& AddBufferView(const void* data, size_t byteLength, size_t byteStride = 0, BufferViewTarget target = BufferViewTarget::UNKNOWN_BUFFER);
+            const BufferView& AddBufferView(Detail::Optional<BufferViewTarget> target);
+            const BufferView& AddBufferView(const void* data, size_t byteLength, Detail::Optional<size_t> byteStride = {}, Detail::Optional<BufferViewTarget> target = {});
 
             template<typename T>
-            const BufferView& AddBufferView(const std::vector<T>& data, size_t byteStride = 0, BufferViewTarget target = BufferViewTarget::UNKNOWN_BUFFER)
+            const BufferView& AddBufferView(const std::vector<T>& data, Detail::Optional<size_t> byteStride = {}, Detail::Optional<BufferViewTarget> target = {})
             {
                 return AddBufferView(data.data(), data.size() * sizeof(T), byteStride, target);
             }

--- a/GLTFSDK/Inc/GLTFSDK/ExtensionsKHR.h
+++ b/GLTFSDK/Inc/GLTFSDK/ExtensionsKHR.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <GLTFSDK/ExtensionHandlers.h>
+#include <GLTFSDK/Optional.h>
 
 #include <memory>
 #include <string>
@@ -84,8 +85,7 @@ namespace Microsoft
                     Vector2 offset;
                     float rotation;
                     Vector2 scale;
-                    // TexCoord is optional
-                    std::unique_ptr<size_t> texCoord;
+                    Detail::Optional<size_t> texCoord; // TexCoord is a optional property
 
                     std::unique_ptr<Extension> Clone() const override;
                     bool IsEqual(const Extension& rhs) const override;

--- a/GLTFSDK/Inc/GLTFSDK/ExtensionsKHR.h
+++ b/GLTFSDK/Inc/GLTFSDK/ExtensionsKHR.h
@@ -85,7 +85,7 @@ namespace Microsoft
                     Vector2 offset;
                     float rotation;
                     Vector2 scale;
-                    Detail::Optional<size_t> texCoord; // TexCoord is a optional property
+                    Optional<size_t> texCoord; // TexCoord is a optional property
 
                     std::unique_ptr<Extension> Clone() const override;
                     bool IsEqual(const Extension& rhs) const override;

--- a/GLTFSDK/Inc/GLTFSDK/ExtensionsKHR.h
+++ b/GLTFSDK/Inc/GLTFSDK/ExtensionsKHR.h
@@ -85,7 +85,7 @@ namespace Microsoft
                     Vector2 offset;
                     float rotation;
                     Vector2 scale;
-                    Optional<size_t> texCoord; // TexCoord is a optional property
+                    Optional<size_t> texCoord; // TexCoord is an optional property
 
                     std::unique_ptr<Extension> Clone() const override;
                     bool IsEqual(const Extension& rhs) const override;

--- a/GLTFSDK/Inc/GLTFSDK/GLTF.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLTF.h
@@ -17,6 +17,19 @@
 #include <utility>
 #include <vector>
 
+//TODO: use Detail::Optional for:
+
+// gltf.scene(i.e. default scene)
+
+// bufferView.byteStride
+// bufferView.target
+
+// perspective.aspectRatio -> if not defined use the aspect ratio of the 'canvas'
+// perspective.zfar -> if undefined runtime must use an infinite projection matrix
+
+// sampler.magFilter->runtime can select a suitable value if not defined
+// sampler.minFilter->runtime can select a suitable value if not defined
+
 namespace Microsoft
 {
     namespace glTF

--- a/GLTFSDK/Inc/GLTFSDK/GLTF.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLTF.h
@@ -332,8 +332,8 @@ namespace Microsoft
             std::string bufferId;
             size_t byteOffset = 0U;
             size_t byteLength = 0U;
-            Detail::Optional<size_t> byteStride;
-            Detail::Optional<BufferViewTarget> target;
+            Optional<size_t> byteStride;
+            Optional<BufferViewTarget> target;
 
             bool operator==(const BufferView& rhs) const
             {
@@ -956,9 +956,9 @@ namespace Microsoft
 
         struct Perspective : Projection
         {
-            Detail::Optional<float> aspectRatio;
+            Optional<float> aspectRatio;
             float yfov;
-            Detail::Optional<float> zfar;
+            Optional<float> zfar;
 
             Perspective(float znear, float yfov) :
                 Projection(znear),
@@ -1196,8 +1196,8 @@ namespace Microsoft
         {
             // The glTF spec doesn't define default values for magFilter and minFilter members. When
             // filtering options are not defined implementations are free to select a suitable value
-            Detail::Optional<MagFilterMode> magFilter;
-            Detail::Optional<MinFilterMode> minFilter;
+            Optional<MagFilterMode> magFilter;
+            Optional<MinFilterMode> minFilter;
             WrapMode wrapS = Wrap_REPEAT;
             WrapMode wrapT = Wrap_REPEAT;
 

--- a/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
@@ -137,14 +137,13 @@ namespace Microsoft
 
                 const size_t offset = accessor.byteOffset + bufferView.byteOffset;
 
-                if (bufferView.byteStride == 0U ||
-                    bufferView.byteStride == elementSize)
+                if (!bufferView.byteStride || bufferView.byteStride.Get() == elementSize)
                 {
                     data = ReadBinaryData<T>(buffer, offset, accessor.count * typeCount);
                 }
                 else
                 {
-                    data = ReadBinaryDataInterleaved<T>(buffer, offset, accessor.count, typeCount, bufferView.byteStride);
+                    data = ReadBinaryDataInterleaved<T>(buffer, offset, accessor.count, typeCount, bufferView.byteStride.Get());
                 }
 
                 return data;
@@ -169,14 +168,13 @@ namespace Microsoft
 
                     const size_t offset = accessor.byteOffset + bufferView.byteOffset;
 
-                    if (bufferView.byteStride == 0U ||
-                        bufferView.byteStride == elementSize)
+                    if (!bufferView.byteStride || bufferView.byteStride.Get() == elementSize)
                     {
                         baseData = ReadBinaryData<T>(buffer, offset, accessor.count * typeCount);
                     }
                     else
                     {
-                        baseData = ReadBinaryDataInterleaved<T>(buffer, offset, accessor.count, typeCount, bufferView.byteStride);
+                        baseData = ReadBinaryDataInterleaved<T>(buffer, offset, accessor.count, typeCount, bufferView.byteStride.Get());
                     }
                 }
 
@@ -367,26 +365,24 @@ namespace Microsoft
 
                 std::vector<I> indices;
 
-                if (indicesBufferView.byteStride == 0U ||
-                    indicesBufferView.byteStride == sizeof(I))
+                if (!indicesBufferView.byteStride || indicesBufferView.byteStride.Get() == sizeof(I))
                 {
                     indices = ReadBinaryData<I>(indicesBuffer, indicesOffset, count);
                 }
                 else
                 {
-                    indices = ReadBinaryDataInterleaved<I>(indicesBuffer, indicesOffset, count, 1U, indicesBufferView.byteStride);
+                    indices = ReadBinaryDataInterleaved<I>(indicesBuffer, indicesOffset, count, 1U, indicesBufferView.byteStride.Get());
                 }
 
                 std::vector<T> values;
 
-                if (valuesBufferView.byteStride == 0U ||
-                    valuesBufferView.byteStride == elementSize)
+                if (!valuesBufferView.byteStride || valuesBufferView.byteStride.Get() == elementSize)
                 {
                     values = ReadBinaryData<T>(valuesBuffer, valuesOffset, count * typeCount);
                 }
                 else
                 {
-                    values = ReadBinaryDataInterleaved<T>(valuesBuffer, valuesOffset, count, typeCount, valuesBufferView.byteStride);
+                    values = ReadBinaryDataInterleaved<T>(valuesBuffer, valuesOffset, count, typeCount, valuesBufferView.byteStride.Get());
                 }
 
                 for (size_t i = 0; i < indices.size(); i++)

--- a/GLTFSDK/Inc/GLTFSDK/Optional.h
+++ b/GLTFSDK/Inc/GLTFSDK/Optional.h
@@ -17,16 +17,16 @@ namespace Microsoft
             public:
                 void* GetStorage()
                 {
-                    return data;
+                    return storage;
                 }
 
                 const void* GetStorage() const
                 {
-                    return data;
+                    return storage;
                 }
 
             protected:
-                alignas(A) unsigned char data[N];
+                alignas(A) unsigned char storage[N];
             };
 
             template<typename T>

--- a/GLTFSDK/Inc/GLTFSDK/Optional.h
+++ b/GLTFSDK/Inc/GLTFSDK/Optional.h
@@ -9,29 +9,8 @@ namespace Microsoft
 {
     namespace glTF
     {
-        namespace Detail
-        {
-            template<size_t N, size_t A>
-            class OptionalStorage
-            {
-            public:
-                void* GetStorage()
-                {
-                    return storage;
-                }
-
-                const void* GetStorage() const
-                {
-                    return storage;
-                }
-
-            protected:
-                alignas(A) unsigned char storage[N];
-            };
-        }
-
         template<typename T>
-        class Optional final : private Detail::OptionalStorage<sizeof(T), alignof(T)>
+        class Optional final
         {
         public:
             Optional() : isConstructed(false)
@@ -123,15 +102,13 @@ namespace Microsoft
                 {
                     new (rhs.GetStorage()) T(std::move(lhs.Get()));
                     rhs.isConstructed = true;
-                    lhs.Get().~T(); // In-place delete;
-                    lhs.isConstructed = false;
+                    lhs.Reset();
                 }
                 else if (rhs)
                 {
                     new (lhs.GetStorage()) T(std::move(rhs.Get()));
                     lhs.isConstructed = true;
-                    rhs.Get().~T(); // In-place delete;
-                    rhs.isConstructed = false;
+                    rhs.Reset();
                 }
             }
 
@@ -191,6 +168,18 @@ namespace Microsoft
             }
 
         private:
+            void* GetStorage()
+            {
+                return storage;
+            }
+
+            const void* GetStorage() const
+            {
+                return storage;
+            }
+
+            alignas(alignof(T)) unsigned char storage[sizeof(T)];
+
             bool isConstructed;
         };
 

--- a/GLTFSDK/Inc/GLTFSDK/Optional.h
+++ b/GLTFSDK/Inc/GLTFSDK/Optional.h
@@ -28,182 +28,182 @@ namespace Microsoft
             protected:
                 alignas(A) unsigned char storage[N];
             };
+        }
 
-            template<typename T>
-            class Optional final : private OptionalStorage<sizeof(T), alignof(T)>
+        template<typename T>
+        class Optional final : private Detail::OptionalStorage<sizeof(T), alignof(T)>
+        {
+        public:
+            Optional() : isConstructed(false)
             {
-            public:
-                Optional() : isConstructed(false)
+            }
+
+            Optional(T&& t) : isConstructed(true)
+            {
+                new (this->GetStorage()) T(std::move(t)); // In-place new;
+            }
+
+            Optional(const T& t) : isConstructed(true)
+            {
+                new (this->GetStorage()) T(t); // In-place new;
+            }
+
+            Optional(Optional<T>&& other) : isConstructed(false)
+            {
+                if (other.isConstructed)
                 {
+                    Swap(other);
+                }
+            }
+
+            Optional(const Optional& other) : isConstructed(other.isConstructed)
+            {
+                if (other.isConstructed)
+                {
+                    new (this->GetStorage()) T(other.Get()); // In-place new;
+                }
+            }
+
+            ~Optional()
+            {
+                Reset();
+            }
+
+            T& Get()
+            {
+                if (isConstructed)
+                {
+                    return *static_cast<T*>(this->GetStorage());
+                }
+                else
+                {
+                    throw GLTFException("Optional has no value");
+                }
+            }
+
+            const T& Get() const
+            {
+                if (isConstructed)
+                {
+                    return *static_cast<const T*>(this->GetStorage());
+                }
+                else
+                {
+                    throw GLTFException("Optional has no value");
+                }
+            }
+
+            bool HasValue() const noexcept
+            {
+                return isConstructed;
+            }
+
+            void Reset()
+            {
+                if (isConstructed)
+                {
+                    Get().~T(); // In-place delete;
                 }
 
-                Optional(T&& t) : isConstructed(true)
+                isConstructed = false;
+            }
+
+            void Swap(Optional& other)
+            {
+                Swap(*this, other);
+            }
+
+            static void Swap(Optional& lhs, Optional& rhs)
+            {
+                if (lhs && rhs)
+                {
+                    std::swap(lhs.Get(), rhs.Get());
+                }
+                else if (lhs)
+                {
+                    new (rhs.GetStorage()) T(std::move(lhs.Get()));
+                    rhs.isConstructed = true;
+                    lhs.Get().~T(); // In-place delete;
+                    lhs.isConstructed = false;
+                }
+                else if (rhs)
+                {
+                    new (lhs.GetStorage()) T(std::move(rhs.Get()));
+                    lhs.isConstructed = true;
+                    rhs.Get().~T(); // In-place delete;
+                    rhs.isConstructed = false;
+                }
+            }
+
+            Optional& operator=(Optional&& other)
+            {
+                if (this != &other)
+                {
+                    Optional(std::move(other)).Swap(*this);
+                }
+
+                return *this;
+            }
+
+            Optional& operator=(const Optional& other)
+            {
+                if (this != &other)
+                {
+                    Optional(other).Swap(*this);
+                }
+
+                return *this;
+            }
+
+            Optional& operator=(T&& t)
+            {
+                if (isConstructed)
+                {
+                    Get() = std::move(t);
+                }
+                else
                 {
                     new (this->GetStorage()) T(std::move(t)); // In-place new;
+                    isConstructed = true;
                 }
 
-                Optional(const T& t) : isConstructed(true)
+                return *this;
+            }
+
+            Optional& operator=(const T& t)
+            {
+                if (isConstructed)
+                {
+                    Get() = t;
+                }
+                else
                 {
                     new (this->GetStorage()) T(t); // In-place new;
+                    isConstructed = true;
                 }
 
-                Optional(Optional<T>&& other) : isConstructed(false)
-                {
-                    if (other.isConstructed)
-                    {
-                        Swap(other);
-                    }
-                }
-
-                Optional(const Optional& other) : isConstructed(other.isConstructed)
-                {
-                    if (other.isConstructed)
-                    {
-                        new (this->GetStorage()) T(other.Get()); // In-place new;
-                    }
-                }
-
-                ~Optional()
-                {
-                    Reset();
-                }
-
-                T& Get()
-                {
-                    if (isConstructed)
-                    {
-                        return *static_cast<T*>(this->GetStorage());
-                    }
-                    else
-                    {
-                        throw GLTFException("Optional has no value");
-                    }
-                }
-
-                const T& Get() const
-                {
-                    if (isConstructed)
-                    {
-                        return *static_cast<const T*>(this->GetStorage());
-                    }
-                    else
-                    {
-                        throw GLTFException("Optional has no value");
-                    }
-                }
-
-                bool HasValue() const noexcept
-                {
-                    return isConstructed;
-                }
-
-                void Reset()
-                {
-                    if (isConstructed)
-                    {
-                        Get().~T(); // In-place delete;
-                    }
-
-                    isConstructed = false;
-                }
-
-                void Swap(Optional& other)
-                {
-                    Swap(*this, other);
-                }
-
-                static void Swap(Optional& lhs, Optional& rhs)
-                {
-                    if (lhs && rhs)
-                    {
-                        std::swap(lhs.Get(), rhs.Get());
-                    }
-                    else if (lhs)
-                    {
-                        new (rhs.GetStorage()) T(std::move(lhs.Get()));
-                        rhs.isConstructed = true;
-                        lhs.Get().~T(); // In-place delete;
-                        lhs.isConstructed = false;
-                    }
-                    else if (rhs)
-                    {
-                        new (lhs.GetStorage()) T(std::move(rhs.Get()));
-                        lhs.isConstructed = true;
-                        rhs.Get().~T(); // In-place delete;
-                        rhs.isConstructed = false;
-                    }
-                }
-
-                Optional& operator=(Optional&& other)
-                {
-                    if (this != &other)
-                    {
-                        Optional(std::move(other)).Swap(*this);
-                    }
-
-                    return *this;
-                }
-
-                Optional& operator=(const Optional& other)
-                {
-                    if (this != &other)
-                    {
-                        Optional(other).Swap(*this);
-                    }
-
-                    return *this;
-                }
-
-                Optional& operator=(T&& t)
-                {
-                    if (isConstructed)
-                    {
-                        Get() = std::move(t);
-                    }
-                    else
-                    {
-                        new (this->GetStorage()) T(std::move(t)); // In-place new;
-                        isConstructed = true;
-                    }
-
-                    return *this;
-                }
-
-                Optional& operator=(const T& t)
-                {
-                    if (isConstructed)
-                    {
-                        Get() = t;
-                    }
-                    else
-                    {
-                        new (this->GetStorage()) T(t); // In-place new;
-                        isConstructed = true;
-                    }
-
-                    return *this;
-                }
-
-                explicit operator bool() const noexcept
-                {
-                    return HasValue();
-                }
-
-            private:
-                bool isConstructed;
-            };
-
-            template<typename T>
-            bool operator==(const Optional<T>& lhs, const Optional<T>& rhs)
-            {
-                return (!lhs && !rhs) || ((lhs && rhs) && (lhs.Get() == rhs.Get()));
+                return *this;
             }
 
-            template<typename T>
-            bool operator!=(const Optional<T>& lhs, const Optional<T>& rhs)
+            explicit operator bool() const noexcept
             {
-                return !(lhs == rhs);
+                return HasValue();
             }
+
+        private:
+            bool isConstructed;
+        };
+
+        template<typename T>
+        bool operator==(const Optional<T>& lhs, const Optional<T>& rhs)
+        {
+            return (!lhs && !rhs) || ((lhs && rhs) && (lhs.Get() == rhs.Get()));
+        }
+
+        template<typename T>
+        bool operator!=(const Optional<T>& lhs, const Optional<T>& rhs)
+        {
+            return !(lhs == rhs);
         }
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/Optional.h
+++ b/GLTFSDK/Inc/GLTFSDK/Optional.h
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "Exceptions.h"
+
+namespace Microsoft
+{
+    namespace glTF
+    {
+        namespace Detail
+        {
+            template<size_t N, size_t A>
+            class OptionalStorage
+            {
+            public:
+                void* GetStorage()
+                {
+                    return data;
+                }
+
+                const void* GetStorage() const
+                {
+                    return data;
+                }
+
+            protected:
+                alignas(A) unsigned char data[N];
+            };
+
+            template<typename T>
+            class Optional final : private OptionalStorage<sizeof(T), alignof(T)>
+            {
+            public:
+                Optional() : isConstructed(false)
+                {
+                }
+
+                Optional(T&& t) : isConstructed(true)
+                {
+                    new (this->GetStorage()) T(std::move(t)); // In-place new;
+                }
+
+                Optional(const T& t) : isConstructed(true)
+                {
+                    new (this->GetStorage()) T(t); // In-place new;
+                }
+
+                Optional(Optional<T>&& other) : isConstructed(false)
+                {
+                    if (other.isConstructed)
+                    {
+                        Swap(other);
+                    }
+                }
+
+                Optional(const Optional& other) : isConstructed(other.isConstructed)
+                {
+                    if (other.isConstructed)
+                    {
+                        new (this->GetStorage()) T(other.Get()); // In-place new;
+                    }
+                }
+
+                ~Optional()
+                {
+                    Reset();
+                }
+
+                T& Get()
+                {
+                    if (isConstructed)
+                    {
+                        return *static_cast<T*>(this->GetStorage());
+                    }
+                    else
+                    {
+                        throw GLTFException("Optional has no value");
+                    }
+                }
+
+                const T& Get() const
+                {
+                    if (isConstructed)
+                    {
+                        return *static_cast<const T*>(this->GetStorage());
+                    }
+                    else
+                    {
+                        throw GLTFException("Optional has no value");
+                    }
+                }
+
+                bool HasValue() const noexcept
+                {
+                    return isConstructed;
+                }
+
+                void Reset()
+                {
+                    if (isConstructed)
+                    {
+                        Get().~T(); // In-place delete;
+                    }
+
+                    isConstructed = false;
+                }
+
+                void Swap(Optional& other)
+                {
+                    Swap(*this, other);
+                }
+
+                static void Swap(Optional& lhs, Optional& rhs)
+                {
+                    if (lhs && rhs)
+                    {
+                        std::swap(lhs.Get(), rhs.Get());
+                    }
+                    else if (lhs)
+                    {
+                        new (rhs.GetStorage()) T(std::move(lhs.Get()));
+                        rhs.isConstructed = true;
+                        lhs.Get().~T(); // In-place delete;
+                        lhs.isConstructed = false;
+                    }
+                    else if (rhs)
+                    {
+                        new (lhs.GetStorage()) T(std::move(rhs.Get()));
+                        lhs.isConstructed = true;
+                        rhs.Get().~T(); // In-place delete;
+                        rhs.isConstructed = false;
+                    }
+                }
+
+                Optional& operator=(Optional&& other)
+                {
+                    if (this != &other)
+                    {
+                        Optional(std::move(other)).Swap(*this);
+                    }
+
+                    return *this;
+                }
+
+                Optional& operator=(const Optional& other)
+                {
+                    if (this != &other)
+                    {
+                        Optional(other).Swap(*this);
+                    }
+
+                    return *this;
+                }
+
+                Optional& operator=(T&& t)
+                {
+                    if (isConstructed)
+                    {
+                        Get() = std::move(t);
+                    }
+                    else
+                    {
+                        new (this->GetStorage()) T(std::move(t)); // In-place new;
+                        isConstructed = true;
+                    }
+
+                    return *this;
+                }
+
+                Optional& operator=(const T& t)
+                {
+                    if (isConstructed)
+                    {
+                        Get() = t;
+                    }
+                    else
+                    {
+                        new (this->GetStorage()) T(t); // In-place new;
+                        isConstructed = true;
+                    }
+
+                    return *this;
+                }
+
+                explicit operator bool() const noexcept
+                {
+                    return HasValue();
+                }
+
+            private:
+                bool isConstructed;
+            };
+
+            template<typename T>
+            bool operator==(const Optional<T>& lhs, const Optional<T>& rhs)
+            {
+                return (!lhs && !rhs) || ((lhs && rhs) && (lhs.Get() == rhs.Get()));
+            }
+
+            template<typename T>
+            bool operator!=(const Optional<T>& lhs, const Optional<T>& rhs)
+            {
+                return !(lhs == rhs);
+            }
+        }
+    }
+}

--- a/GLTFSDK/Source/BufferBuilder.cpp
+++ b/GLTFSDK/Source/BufferBuilder.cpp
@@ -62,7 +62,7 @@ const Buffer& BufferBuilder::AddBuffer(const char* bufferId)
     return bufferRef;
 }
 
-const BufferView& BufferBuilder::AddBufferView(Detail::Optional<BufferViewTarget> target)
+const BufferView& BufferBuilder::AddBufferView(Optional<BufferViewTarget> target)
 {
     Buffer& buffer = m_buffers.Back();
     BufferView bufferView;
@@ -80,7 +80,7 @@ const BufferView& BufferBuilder::AddBufferView(Detail::Optional<BufferViewTarget
     return m_bufferViews.Append(std::move(bufferView), AppendIdPolicy::GenerateOnEmpty);
 }
 
-const BufferView& BufferBuilder::AddBufferView(const void* data, size_t byteLength, Detail::Optional<size_t> byteStride, Detail::Optional<BufferViewTarget> target)
+const BufferView& BufferBuilder::AddBufferView(const void* data, size_t byteLength, Optional<size_t> byteStride, Optional<BufferViewTarget> target)
 {
     Buffer& buffer = m_buffers.Back();
     BufferView bufferView;

--- a/GLTFSDK/Source/BufferBuilder.cpp
+++ b/GLTFSDK/Source/BufferBuilder.cpp
@@ -62,7 +62,7 @@ const Buffer& BufferBuilder::AddBuffer(const char* bufferId)
     return bufferRef;
 }
 
-const BufferView& BufferBuilder::AddBufferView(BufferViewTarget target)
+const BufferView& BufferBuilder::AddBufferView(Detail::Optional<BufferViewTarget> target)
 {
     Buffer& buffer = m_buffers.Back();
     BufferView bufferView;
@@ -80,7 +80,7 @@ const BufferView& BufferBuilder::AddBufferView(BufferViewTarget target)
     return m_bufferViews.Append(std::move(bufferView), AppendIdPolicy::GenerateOnEmpty);
 }
 
-const BufferView& BufferBuilder::AddBufferView(const void* data, size_t byteLength, size_t byteStride, BufferViewTarget target)
+const BufferView& BufferBuilder::AddBufferView(const void* data, size_t byteLength, Detail::Optional<size_t> byteStride, Detail::Optional<BufferViewTarget> target)
 {
     Buffer& buffer = m_buffers.Back();
     BufferView bufferView;
@@ -170,7 +170,8 @@ void BufferBuilder::AddAccessors(const void* data, size_t count, size_t byteStri
         extent = count * byteStride;
 
         // Ensure all accessors fit within the buffer view's extent.
-        const size_t lastElement = (count - 1) * bufferView.byteStride;
+        const size_t lastElement = (count - 1) * (bufferView.byteStride ? bufferView.byteStride.Get() : 0U);
+
         for (size_t i = 0; i < descCount; ++i)
         {
             const size_t accessorSize = Accessor::GetTypeCount(pDescs[i].accessorType) * Accessor::GetComponentTypeSize(pDescs[i].componentType);

--- a/GLTFSDK/Source/Deserialize.cpp
+++ b/GLTFSDK/Source/Deserialize.cpp
@@ -183,7 +183,6 @@ namespace
         bv.byteLength = GetValue<size_t>(FindRequiredMember("byteLength", v)->value);
 
         auto itByteStride = v.FindMember("byteStride");
-
         if (itByteStride != v.MemberEnd())
         {
             bv.byteStride = itByteStride->value.GetUint();
@@ -191,7 +190,6 @@ namespace
 
         // When target is not provided, the bufferView contains animation or skin data
         auto itTarget = v.FindMember("target");
-
         if (itTarget != v.MemberEnd())
         {
             bv.target = static_cast<BufferViewTarget>(itTarget->value.GetUint());
@@ -410,16 +408,14 @@ namespace
         if (projectionType == "perspective")
         {
             auto perspectiveIt = v.FindMember("perspective");
-
             if (perspectiveIt == v.MemberEnd())
             {
                 throw InvalidGLTFException("Camera perspective projection undefined");
             }
 
-            Detail::Optional<float> aspectRatio;
+            Optional<float> aspectRatio;
 
             auto itAspectRatio = perspectiveIt->value.FindMember("target");
-
             if (itAspectRatio != perspectiveIt->value.MemberEnd())
             {
                 aspectRatio = itAspectRatio->value.GetFloat();
@@ -428,10 +424,9 @@ namespace
             float yfov = GetValue<float>(FindRequiredMember("yfov", perspectiveIt->value)->value);
             float znear = GetValue<float>(FindRequiredMember("znear", perspectiveIt->value)->value);
 
-            Detail::Optional<float> zfar;
+            Optional<float> zfar;
 
             auto itZFar = perspectiveIt->value.FindMember("zfar");
-
             if (itZFar != perspectiveIt->value.MemberEnd())
             {
                 zfar = itZFar->value.GetFloat();
@@ -514,14 +509,12 @@ namespace
         sampler.wrapS = Sampler::GetSamplerWrapMode(GetMemberValueOrDefault<unsigned int>(v, "wrapS", static_cast<unsigned int>(WrapMode::Wrap_REPEAT)));
 
         auto itMin = v.FindMember("minFilter");
-
         if (itMin != v.MemberEnd())
         {
             sampler.minFilter = Sampler::GetSamplerMinFilterMode(itMin->value.GetUint());
         }
 
         auto itMax = v.FindMember("maxFilter");
-
         if (itMax != v.MemberEnd())
         {
             sampler.magFilter = Sampler::GetSamplerMagFilterMode(itMax->value.GetUint());

--- a/GLTFSDK/Source/Deserialize.cpp
+++ b/GLTFSDK/Source/Deserialize.cpp
@@ -514,10 +514,10 @@ namespace
             sampler.minFilter = Sampler::GetSamplerMinFilterMode(itMin->value.GetUint());
         }
 
-        auto itMax = v.FindMember("maxFilter");
-        if (itMax != v.MemberEnd())
+        auto itMag = v.FindMember("magFilter");
+        if (itMag != v.MemberEnd())
         {
-            sampler.magFilter = Sampler::GetSamplerMagFilterMode(itMax->value.GetUint());
+            sampler.magFilter = Sampler::GetSamplerMagFilterMode(itMag->value.GetUint());
         }
 
         ParseProperty(v, sampler, extensionDeserializer);

--- a/GLTFSDK/Source/ExtensionsKHR.cpp
+++ b/GLTFSDK/Source/ExtensionsKHR.cpp
@@ -406,19 +406,17 @@ std::unique_ptr<Extension> KHR::MeshPrimitives::DeserializeDracoMeshCompression(
 KHR::TextureInfos::TextureTransform::TextureTransform() :
     offset(Vector2::ZERO),
     rotation(0.0f),
-    scale(Vector2::ONE)
+    scale(Vector2::ONE),
+    texCoord()
 {
 }
 
 KHR::TextureInfos::TextureTransform::TextureTransform(const TextureTransform& textureTransform) :
     offset(textureTransform.offset),
     rotation(textureTransform.rotation),
-    scale(textureTransform.scale)
+    scale(textureTransform.scale),
+    texCoord(textureTransform.texCoord)
 {
-    if (textureTransform.texCoord)
-    {
-        texCoord = std::make_unique<size_t>(*textureTransform.texCoord);
-    }
 }
 
 std::unique_ptr<Extension> KHR::TextureInfos::TextureTransform::Clone() const
@@ -435,9 +433,7 @@ bool KHR::TextureInfos::TextureTransform::IsEqual(const Extension& rhs) const
         && this->offset == other->offset
         && this->rotation == other->rotation
         && this->scale == other->scale
-        && ((!this->texCoord && !other->texCoord) ||
-            ((this->texCoord && other->texCoord) && 
-                *this->texCoord == *other->texCoord));
+        && this->texCoord == other->texCoord;
 }
 
 std::string KHR::TextureInfos::SerializeTextureTransform(const TextureTransform& textureTransform, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
@@ -463,7 +459,7 @@ std::string KHR::TextureInfos::SerializeTextureTransform(const TextureTransform&
 
         if (textureTransform.texCoord)
         {
-            KHR_textureTransform.AddMember("texCoord", ToKnownSizeType(*textureTransform.texCoord), a);
+            KHR_textureTransform.AddMember("texCoord", ToKnownSizeType(textureTransform.texCoord.Get()), a);
         }
 
         SerializeProperty(gltfDocument, textureTransform, KHR_textureTransform, a, extensionSerializer);
@@ -526,7 +522,7 @@ std::unique_ptr<Extension> KHR::TextureInfos::DeserializeTextureTransform(const 
     auto texCoordIt = sit.FindMember("texCoord");
     if (texCoordIt != sit.MemberEnd())
     {
-        textureTransform.texCoord = std::make_unique<size_t>(static_cast<size_t>(texCoordIt->value.GetUint()));
+        textureTransform.texCoord = static_cast<size_t>(texCoordIt->value.GetUint());
     }
 
     ParseProperty(sit, textureTransform, extensionDeserializer);


### PR DESCRIPTION
Use a utility Optional<T> type for class member variables that are not required and have no default value specified. The following classes have been modified:

- BufferView: byteStride & target members
- Perspective: zfar & aspectRatio members
- Sampler: magFilter & minFilter members
- TextureTransform: texCoord member