### PR TITLE
Add support for missing component types to AnimationUtils::GetRotations

### DIFF
--- a/GLTFSDK.Test/Source/AnimationUtilsTests.cpp
+++ b/GLTFSDK.Test/Source/AnimationUtilsTests.cpp
@@ -19,6 +19,110 @@ namespace Microsoft
     {
         namespace Test
         {
+            namespace
+            {
+                const std::map<const std::type_index, ComponentType> kComponentTypeMap =
+                {
+                    { std::type_index(typeid(float)),    COMPONENT_FLOAT },
+                    { std::type_index(typeid(int8_t)),   COMPONENT_BYTE },
+                    { std::type_index(typeid(uint8_t)),  COMPONENT_UNSIGNED_BYTE },
+                    { std::type_index(typeid(int16_t)),  COMPONENT_SHORT },
+                    { std::type_index(typeid(uint16_t)), COMPONENT_UNSIGNED_SHORT }
+                };
+
+                // Utility for verifying GetMorphWeights
+                template<typename T>
+                void VerifyGetMorphWeights()
+                {
+                    std::vector<float> testValues = { 0.0f, 0.11f, 0.22f, 0.33f, 0.44f, 0.55f, 1.0f };
+
+                    auto readerWriter = std::make_shared<const StreamReaderWriter>();
+                    auto bufferBuilder = BufferBuilder(std::make_unique<GLTFResourceWriter>(readerWriter));
+
+                    bufferBuilder.AddBuffer();
+                    bufferBuilder.AddBufferView(BufferViewTarget::ARRAY_BUFFER);
+
+                    std::vector<T> input;
+                    std::vector<float> expectedOutput;
+                    for (auto& v : testValues)
+                    {
+                        auto c = AnimationUtils::FloatToComponent<T>(v);
+                        input.push_back(c);
+                        expectedOutput.push_back(AnimationUtils::ComponentToFloat(c));
+                    }
+
+                    auto componentType = kComponentTypeMap.find(std::type_index(typeid(T)));
+                    Assert::IsTrue(componentType != kComponentTypeMap.end(), L"ComponentType not found");
+                    auto accessor = bufferBuilder.AddAccessor(input, { TYPE_SCALAR, componentType->second });
+
+                    Document doc;
+                    bufferBuilder.Output(doc);
+
+                    // Verify that we read back what's expected
+                    std::stringstream ss;
+                    ss << "Error extracting weights for component type " << typeid(T).name();
+                    std::string s = ss.str();
+                    std::wstring msg(s.begin(), s.end());
+
+                    // Accessor
+                    GLTFResourceReader reader(readerWriter);
+                    auto output = AnimationUtils::GetMorphWeights(doc, reader, accessor);
+                    AreEqual(expectedOutput, output, msg.c_str());
+
+                    // Sampler
+                    AnimationSampler animationSampler;
+                    animationSampler.outputAccessorId = accessor.id;
+                    output = AnimationUtils::GetMorphWeights(doc, reader, animationSampler);
+                    AreEqual(expectedOutput, output, msg.c_str());
+                }
+
+                // Utility for verifying GetRotations
+                template<typename T>
+                void VerifyGetRotations()
+                {
+                    std::vector<float> testValues = { 0.213941514f, 0.963860869f, -0.158749819f, 0.204712942f };
+
+                    auto readerWriter = std::make_shared<const StreamReaderWriter>();
+                    auto bufferBuilder = BufferBuilder(std::make_unique<GLTFResourceWriter>(readerWriter));
+
+                    bufferBuilder.AddBuffer();
+                    bufferBuilder.AddBufferView(BufferViewTarget::ARRAY_BUFFER);
+
+                    std::vector<T> input;
+                    std::vector<float> expectedOutput;
+                    for (auto& v : testValues)
+                    {
+                        auto c = AnimationUtils::FloatToComponent<T>(v);
+                        input.push_back(c);
+                        expectedOutput.push_back(AnimationUtils::ComponentToFloat(c));
+                    }
+
+                    auto componentType = kComponentTypeMap.find(std::type_index(typeid(T)));
+                    Assert::IsTrue(componentType != kComponentTypeMap.end(), L"ComponentType not found");
+                    auto accessor = bufferBuilder.AddAccessor(input, { TYPE_VEC4, componentType->second });
+
+                    Document doc;
+                    bufferBuilder.Output(doc);
+
+                    // Verify that we read back what's expected
+                    std::stringstream ss;
+                    ss << "Error extracting rotations for component type " << typeid(T).name();
+                    std::string s = ss.str();
+                    std::wstring msg(s.begin(), s.end());
+
+                    // Accessor
+                    GLTFResourceReader reader(readerWriter);
+                    auto output = AnimationUtils::GetRotations(doc, reader, accessor);
+                    AreEqual(expectedOutput, output, msg.c_str());
+
+                    // Sampler
+                    AnimationSampler animationSampler;
+                    animationSampler.outputAccessorId = accessor.id;
+                    output = AnimationUtils::GetRotations(doc, reader, animationSampler);
+                    AreEqual(expectedOutput, output, msg.c_str());
+                }
+            }
+
             GLTFSDK_TEST_CLASS(AnimationUtilsTests)
             {
                 GLTFSDK_TEST_METHOD(AnimationUtilsTests, AnimationUtils_Test_GetKeyframeTimes_Scalar_Float)
@@ -130,52 +234,6 @@ namespace Microsoft
                     AreEqual(input, output);
                 }
 
-                // Utility for verifying GetMorphWeights
-                static std::map< std::type_index, ComponentType> kComponentTypeMap;
-
-                template<typename T>
-                void VerifyGetMorphWeights() const
-                {
-                    std::vector<float> testValues = { 0.0f, 0.11f, 0.22f, 0.33f, 0.44f, 0.55f, 1.0f };
-
-                    auto readerWriter = std::make_shared<const StreamReaderWriter>();
-                    auto bufferBuilder = BufferBuilder(std::make_unique<GLTFResourceWriter>(readerWriter));
-
-                    bufferBuilder.AddBuffer();
-                    bufferBuilder.AddBufferView(BufferViewTarget::ARRAY_BUFFER);
-
-                    std::vector<T> input;
-                    std::vector<float> expectedOutput;
-                    for (auto& v : testValues)
-                    {
-                        auto c = AnimationUtils::FloatToComponent<T>(v);
-                        input.push_back(c);
-                        expectedOutput.push_back(AnimationUtils::ComponentToFloat(c));
-                    }
-          
-                    auto accessor = bufferBuilder.AddAccessor(input, { TYPE_SCALAR, kComponentTypeMap[std::type_index(typeid(T))] });
-
-                    Document doc;
-                    bufferBuilder.Output(doc);
-
-                    // Verify that we read back what's expected
-                    std::stringstream ss;
-                    ss << "Error extracting weights for component type " << typeid(T).name();
-                    std::string s = ss.str();
-                    std::wstring msg(s.begin(), s.end());
-
-                    // Accessor
-                    GLTFResourceReader reader(readerWriter);
-                    auto output = AnimationUtils::GetMorphWeights(doc, reader, accessor);
-                    AreEqual(expectedOutput, output, msg.c_str());
-
-                    // Sampler
-                    AnimationSampler animationSampler;
-                    animationSampler.outputAccessorId = accessor.id;
-                    output = AnimationUtils::GetMorphWeights(doc, reader, animationSampler);
-                    AreEqual(expectedOutput, output, msg.c_str());
-                }
-
                 // Verify GetWeights for all possible component types
                 GLTFSDK_TEST_METHOD(AnimationUtilsTests, AnimationUtils_Test_GetMorphWeights)
                 {
@@ -184,50 +242,6 @@ namespace Microsoft
                     VerifyGetMorphWeights<uint8_t>();
                     VerifyGetMorphWeights<int16_t>();
                     VerifyGetMorphWeights<uint16_t>();
-                }
-
-                // Utility for verifying GetRotations
-                template<typename T>
-                void VerifyGetRotations() const
-                {
-                    std::vector<float> testValues = { 0.213941514f, 0.963860869f, -0.158749819f, 0.204712942f };
-
-                    auto readerWriter = std::make_shared<const StreamReaderWriter>();
-                    auto bufferBuilder = BufferBuilder(std::make_unique<GLTFResourceWriter>(readerWriter));
-
-                    bufferBuilder.AddBuffer();
-                    bufferBuilder.AddBufferView(BufferViewTarget::ARRAY_BUFFER);
-
-                    std::vector<T> input;
-                    std::vector<float> expectedOutput;
-                    for (auto& v : testValues)
-                    {
-                        auto c = AnimationUtils::FloatToComponent<T>(v);
-                        input.push_back(c);
-                        expectedOutput.push_back(AnimationUtils::ComponentToFloat(c));
-                    }
-
-                    auto accessor = bufferBuilder.AddAccessor(input, { TYPE_VEC4, kComponentTypeMap[std::type_index(typeid(T))] });
-
-                    Document doc;
-                    bufferBuilder.Output(doc);
-
-                    // Verify that we read back what's expected
-                    std::stringstream ss;
-                    ss << "Error extracting rotations for component type " << typeid(T).name();
-                    std::string s = ss.str();
-                    std::wstring msg(s.begin(), s.end());
-
-                    // Accessor
-                    GLTFResourceReader reader(readerWriter);
-                    auto output = AnimationUtils::GetRotations(doc, reader, accessor);
-                    AreEqual(expectedOutput, output, msg.c_str());
-
-                    // Sampler
-                    AnimationSampler animationSampler;
-                    animationSampler.outputAccessorId = accessor.id;
-                    output = AnimationUtils::GetRotations(doc, reader, animationSampler);
-                    AreEqual(expectedOutput, output, msg.c_str());
                 }
 
                 // Verify GetRotations for all possible component types
@@ -239,15 +253,6 @@ namespace Microsoft
                     VerifyGetRotations<int16_t>();
                     VerifyGetRotations<uint16_t>();
                 }
-            };
-
-            std::map< std::type_index, ComponentType> AnimationUtilsTests::kComponentTypeMap =
-            {
-                { std::type_index(typeid(float)),    COMPONENT_FLOAT },
-                { std::type_index(typeid(int8_t)),   COMPONENT_BYTE },
-                { std::type_index(typeid(uint8_t)),  COMPONENT_UNSIGNED_BYTE },
-                { std::type_index(typeid(int16_t)),  COMPONENT_SHORT },
-                { std::type_index(typeid(uint16_t)), COMPONENT_UNSIGNED_SHORT }
             };
         }
     }

--- a/GLTFSDK.Test/Source/AnimationUtilsTests.cpp
+++ b/GLTFSDK.Test/Source/AnimationUtilsTests.cpp
@@ -131,18 +131,11 @@ namespace Microsoft
                 }
 
                 // Utility for verifying GetMorphWeights
-                template<typename T>
-                void VerifyGetMorphWeights()
-                {
-                    std::map< std::type_index, ComponentType> componentTypeMap =
-                    {
-                        { std::type_index(typeid(float)),    COMPONENT_FLOAT },
-                        { std::type_index(typeid(int8_t)),   COMPONENT_BYTE },
-                        { std::type_index(typeid(uint8_t)),  COMPONENT_UNSIGNED_BYTE },
-                        { std::type_index(typeid(int16_t)),  COMPONENT_SHORT },
-                        { std::type_index(typeid(uint16_t)), COMPONENT_UNSIGNED_SHORT }
-                    };
+                static std::map< std::type_index, ComponentType> kComponentTypeMap;
 
+                template<typename T>
+                void VerifyGetMorphWeights() const
+                {
                     std::vector<float> testValues = { 0.0f, 0.11f, 0.22f, 0.33f, 0.44f, 0.55f, 1.0f };
 
                     auto readerWriter = std::make_shared<const StreamReaderWriter>();
@@ -160,7 +153,7 @@ namespace Microsoft
                         expectedOutput.push_back(AnimationUtils::ComponentToFloat(c));
                     }
           
-                    auto accessor = bufferBuilder.AddAccessor(input, { TYPE_SCALAR, componentTypeMap[std::type_index(typeid(T))] });
+                    auto accessor = bufferBuilder.AddAccessor(input, { TYPE_SCALAR, kComponentTypeMap[std::type_index(typeid(T))] });
 
                     Document doc;
                     bufferBuilder.Output(doc);
@@ -195,17 +188,8 @@ namespace Microsoft
 
                 // Utility for verifying GetRotations
                 template<typename T>
-                void VerifyGetRotations()
+                void VerifyGetRotations() const
                 {
-                    std::map< std::type_index, ComponentType> componentTypeMap =
-                    {
-                        { std::type_index(typeid(float)),    COMPONENT_FLOAT },
-                        { std::type_index(typeid(int8_t)),   COMPONENT_BYTE },
-                        { std::type_index(typeid(uint8_t)),  COMPONENT_UNSIGNED_BYTE },
-                        { std::type_index(typeid(int16_t)),  COMPONENT_SHORT },
-                        { std::type_index(typeid(uint16_t)), COMPONENT_UNSIGNED_SHORT }
-                    };
-
                     std::vector<float> testValues = { 0.213941514f, 0.963860869f, -0.158749819f, 0.204712942f };
 
                     auto readerWriter = std::make_shared<const StreamReaderWriter>();
@@ -223,7 +207,7 @@ namespace Microsoft
                         expectedOutput.push_back(AnimationUtils::ComponentToFloat(c));
                     }
 
-                    auto accessor = bufferBuilder.AddAccessor(input, { TYPE_VEC4, componentTypeMap[std::type_index(typeid(T))] });
+                    auto accessor = bufferBuilder.AddAccessor(input, { TYPE_VEC4, kComponentTypeMap[std::type_index(typeid(T))] });
 
                     Document doc;
                     bufferBuilder.Output(doc);
@@ -255,6 +239,15 @@ namespace Microsoft
                     VerifyGetRotations<int16_t>();
                     VerifyGetRotations<uint16_t>();
                 }
+            };
+
+            std::map< std::type_index, ComponentType> AnimationUtilsTests::kComponentTypeMap =
+            {
+                { std::type_index(typeid(float)),    COMPONENT_FLOAT },
+                { std::type_index(typeid(int8_t)),   COMPONENT_BYTE },
+                { std::type_index(typeid(uint8_t)),  COMPONENT_UNSIGNED_BYTE },
+                { std::type_index(typeid(int16_t)),  COMPONENT_SHORT },
+                { std::type_index(typeid(uint16_t)), COMPONENT_UNSIGNED_SHORT }
             };
         }
     }

--- a/GLTFSDK/Source/AnimationUtils.cpp
+++ b/GLTFSDK/Source/AnimationUtils.cpp
@@ -11,17 +11,17 @@ using namespace Microsoft::glTF;
 namespace
 {
     template<typename T>
-    std::vector<float> GetMorphWeightFloats(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
+    std::vector<float> GetDataFloats(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
     {
-        std::vector<T> rawWeights = reader.ReadBinaryData<T>(doc, accessor);
+        std::vector<T> rawData = reader.ReadBinaryData<T>(doc, accessor);
 
-        std::vector<float> floatWeights;
-        floatWeights.reserve(rawWeights.size());
+        std::vector<float> floatData;
+        floatData.reserve(rawData.size());
 
-        std::transform(rawWeights.begin(), rawWeights.end(), std::back_inserter(floatWeights),
+        std::transform(rawData.begin(), rawData.end(), std::back_inserter(floatData),
             [](T value) -> float { return AnimationUtils::ComponentToFloat(value); });
 
-        return floatWeights;
+        return floatData;
     }
 }
 
@@ -95,12 +95,21 @@ std::vector<float> AnimationUtils::GetRotations(const Document& doc, const GLTFR
         throw GLTFException("Invalid type for rotations accessor " + accessor.id);
     }
 
-    if (accessor.componentType != COMPONENT_FLOAT)
+    switch (accessor.componentType)
     {
+    case COMPONENT_FLOAT:
+        return reader.ReadBinaryData<float>(doc, accessor);
+    case COMPONENT_BYTE:
+        return GetDataFloats<int8_t>(doc, reader, accessor);
+    case COMPONENT_UNSIGNED_BYTE:
+        return GetDataFloats<uint8_t>(doc, reader, accessor);
+    case COMPONENT_SHORT:
+        return GetDataFloats<int16_t>(doc, reader, accessor);
+    case COMPONENT_UNSIGNED_SHORT:
+        return GetDataFloats<uint16_t>(doc, reader, accessor);
+    default:
         throw GLTFException("Invalid componentType for rotations accessor " + accessor.id);
     }
-
-    return reader.ReadBinaryData<float>(doc, accessor);
 }
 
 std::vector<float> AnimationUtils::GetRotations(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler)
@@ -130,8 +139,6 @@ std::vector<float> AnimationUtils::GetScales(const Document& doc, const GLTFReso
     return GetScales(doc, reader, accessor);
 }
 
-
-
 std::vector<float> AnimationUtils::GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
 {
     if (accessor.type != TYPE_SCALAR)
@@ -142,30 +149,15 @@ std::vector<float> AnimationUtils::GetMorphWeights(const Document& doc, const GL
     switch (accessor.componentType)
     {
     case COMPONENT_FLOAT: 
-    { 
         return reader.ReadBinaryData<float>(doc, accessor);
-    }
-    break;
     case COMPONENT_BYTE:
-    {
-        return GetMorphWeightFloats<int8_t>(doc, reader, accessor);
-    }
-    break;
+        return GetDataFloats<int8_t>(doc, reader, accessor);
     case COMPONENT_UNSIGNED_BYTE:
-    {
-        return GetMorphWeightFloats<uint8_t>(doc, reader, accessor);
-    }
-    break;
+        return GetDataFloats<uint8_t>(doc, reader, accessor);
     case COMPONENT_SHORT:
-    {
-        return GetMorphWeightFloats<int16_t>(doc, reader, accessor);
-    }
-    break;
+        return GetDataFloats<int16_t>(doc, reader, accessor);
     case COMPONENT_UNSIGNED_SHORT:
-    {
-        return GetMorphWeightFloats<uint16_t>(doc, reader, accessor);
-    }
-    break;
+        return GetDataFloats<uint16_t>(doc, reader, accessor);
     default:
         throw GLTFException("Invalid componentType for weights accessor " + accessor.id);
     }


### PR DESCRIPTION
Fix a mismatch between the existing code, which only supported FLOATs, and the spec which allows all these:

"rotation" | "VEC4" | 5126 (FLOAT) 5120 (BYTE) normalized 5121 (UNSIGNED_BYTE) normalized 5122 (SHORT) normalized 5123 (UNSIGNED_SHORT) normalized | XYZW rotation quaternion
-- | -- | -- | --
