### PR TITLE
Fix serialization of texture transform extension for normalTexture

### DIFF
--- a/GLTFSDK.Test/Resources/gltf/TextureTransformTest.gltf
+++ b/GLTFSDK.Test/Resources/gltf/TextureTransformTest.gltf
@@ -109,6 +109,28 @@
           }
         },
         "metallicFactor": 0
+      },
+      "normalTexture": {
+        "index": 0,
+        "extensions": {
+          "KHR_texture_transform": {
+            "offset": [
+              0.5,
+              0.0
+            ]
+          }
+        }
+      },
+      "occlusionTexture": {
+        "index": 0,
+        "extensions": {
+          "KHR_texture_transform": {
+            "offset": [
+              0.5,
+              0.0
+            ]
+          }
+        }
       }
     },
     {

--- a/GLTFSDK.Test/Source/GLTFExtensionsTests.cpp
+++ b/GLTFSDK.Test/Source/GLTFExtensionsTests.cpp
@@ -456,6 +456,68 @@ namespace Microsoft
                     checkTextureInfo(doc.materials[5], Vector2(-0.2f, -0.1f), 0.3f, Vector2(1.5f, 1.5f));
                 }
 
+                GLTFSDK_TEST_METHOD(ExtensionsTests, Extensions_Test_HasTextureTransformExtension_Normal)
+                {
+                  const auto inputJson = ReadLocalJson(c_textureTransformTestJson);
+
+                  const auto extensionDeserializer = KHR::GetKHRExtensionDeserializer();
+                  auto doc = Deserialize(inputJson, extensionDeserializer);
+
+                  auto checkTextureInfo = [](
+                                             const Material& material,
+                                             const Vector2& offset, float rotation, const Vector2& scale, Optional<size_t> texCoord = {})
+                  {
+                    auto& textureInfo = material.normalTexture;
+
+                    Assert::IsTrue(textureInfo.HasExtension<KHR::TextureInfos::TextureTransform>());
+
+                    auto& textureTransform = textureInfo.GetExtension<KHR::TextureInfos::TextureTransform>();
+
+                    KHR::TextureInfos::TextureTransform expectedTextureTransform;
+                    expectedTextureTransform.offset = offset;
+                    expectedTextureTransform.scale = scale;
+                    expectedTextureTransform.rotation = rotation;
+                    expectedTextureTransform.texCoord = texCoord;
+
+                    Assert::IsTrue(textureTransform == expectedTextureTransform);
+                  };
+
+                  Assert::IsTrue(doc.materials.Size() == 9);
+
+                  checkTextureInfo(doc.materials[0], Vector2(0.5f, 0.0f), 0.0f, Vector2(1.0f, 1.0f));
+                }
+
+                GLTFSDK_TEST_METHOD(ExtensionsTests, Extensions_Test_HasTextureTransformExtension_Occlusion)
+                {
+                  const auto inputJson = ReadLocalJson(c_textureTransformTestJson);
+
+                  const auto extensionDeserializer = KHR::GetKHRExtensionDeserializer();
+                  auto doc = Deserialize(inputJson, extensionDeserializer);
+
+                  auto checkTextureInfo = [](
+                                             const Material& material,
+                                             const Vector2& offset, float rotation, const Vector2& scale, Optional<size_t> texCoord = {})
+                  {
+                    auto& textureInfo = material.occlusionTexture;
+
+                    Assert::IsTrue(textureInfo.HasExtension<KHR::TextureInfos::TextureTransform>());
+
+                    auto& textureTransform = textureInfo.GetExtension<KHR::TextureInfos::TextureTransform>();
+
+                    KHR::TextureInfos::TextureTransform expectedTextureTransform;
+                    expectedTextureTransform.offset = offset;
+                    expectedTextureTransform.scale = scale;
+                    expectedTextureTransform.rotation = rotation;
+                    expectedTextureTransform.texCoord = texCoord;
+
+                    Assert::IsTrue(textureTransform == expectedTextureTransform);
+                  };
+
+                  Assert::IsTrue(doc.materials.Size() == 9);
+
+                  checkTextureInfo(doc.materials[0], Vector2(0.5f, 0.0f), 0.0f, Vector2(1.0f, 1.0f));
+                }
+
                 GLTFSDK_TEST_METHOD(ExtensionsTests, Extensions_Test_HasTextureTransformExtension_TexCoord)
                 {
                     // Ensure the optionality of the texCoord property is preserved

--- a/GLTFSDK.Test/Source/OptionalTests.cpp
+++ b/GLTFSDK.Test/Source/OptionalTests.cpp
@@ -295,7 +295,7 @@ namespace Microsoft
                         Optional<std::string> opt;
 
                         Assert::IsFalse(opt.HasValue());
-                        opt = opt;
+                        opt = opt.Get();
                         Assert::IsFalse(opt.HasValue());
                     }
 
@@ -304,7 +304,7 @@ namespace Microsoft
                         Optional<std::string> opt("Init");
 
                         Assert::IsTrue(opt.HasValue());
-                        opt = opt;
+                        opt = opt.Get();
                         Assert::IsTrue(opt.HasValue());
 
                         Assert::AreEqual("Init", opt.Get().c_str());

--- a/GLTFSDK.Test/Source/OptionalTests.cpp
+++ b/GLTFSDK.Test/Source/OptionalTests.cpp
@@ -295,7 +295,7 @@ namespace Microsoft
                         Optional<std::string> opt;
 
                         Assert::IsFalse(opt.HasValue());
-                        opt = opt.Get();
+                        opt = opt;
                         Assert::IsFalse(opt.HasValue());
                     }
 
@@ -304,7 +304,7 @@ namespace Microsoft
                         Optional<std::string> opt("Init");
 
                         Assert::IsTrue(opt.HasValue());
-                        opt = opt.Get();
+                        opt = opt;
                         Assert::IsTrue(opt.HasValue());
 
                         Assert::AreEqual("Init", opt.Get().c_str());

--- a/GLTFSDK/Source/ExtensionsKHR.cpp
+++ b/GLTFSDK/Source/ExtensionsKHR.cpp
@@ -136,6 +136,7 @@ ExtensionSerializer KHR::GetKHRExtensionSerializer()
     extensionSerializer.AddHandler<Unlit, Material>(UNLIT_NAME, SerializeUnlit);
     extensionSerializer.AddHandler<DracoMeshCompression, MeshPrimitive>(DRACOMESHCOMPRESSION_NAME, SerializeDracoMeshCompression);
     extensionSerializer.AddHandler<TextureTransform, TextureInfo>(TEXTURETRANSFORM_NAME, SerializeTextureTransform);
+    extensionSerializer.AddHandler<TextureTransform, Material::NormalTextureInfo>(TEXTURETRANSFORM_NAME, SerializeTextureTransform);
     return extensionSerializer;
 }
 
@@ -150,6 +151,7 @@ ExtensionDeserializer KHR::GetKHRExtensionDeserializer()
     extensionDeserializer.AddHandler<Unlit, Material>(UNLIT_NAME, DeserializeUnlit);
     extensionDeserializer.AddHandler<DracoMeshCompression, MeshPrimitive>(DRACOMESHCOMPRESSION_NAME, DeserializeDracoMeshCompression);
     extensionDeserializer.AddHandler<TextureTransform, TextureInfo>(TEXTURETRANSFORM_NAME, DeserializeTextureTransform);
+    extensionDeserializer.AddHandler<TextureTransform, Material::NormalTextureInfo>(TEXTURETRANSFORM_NAME, DeserializeTextureTransform);
     return extensionDeserializer;
 }
 

--- a/GLTFSDK/Source/ExtensionsKHR.cpp
+++ b/GLTFSDK/Source/ExtensionsKHR.cpp
@@ -137,6 +137,7 @@ ExtensionSerializer KHR::GetKHRExtensionSerializer()
     extensionSerializer.AddHandler<DracoMeshCompression, MeshPrimitive>(DRACOMESHCOMPRESSION_NAME, SerializeDracoMeshCompression);
     extensionSerializer.AddHandler<TextureTransform, TextureInfo>(TEXTURETRANSFORM_NAME, SerializeTextureTransform);
     extensionSerializer.AddHandler<TextureTransform, Material::NormalTextureInfo>(TEXTURETRANSFORM_NAME, SerializeTextureTransform);
+    extensionSerializer.AddHandler<TextureTransform, Material::OcclusionTextureInfo>(TEXTURETRANSFORM_NAME, SerializeTextureTransform);
     return extensionSerializer;
 }
 
@@ -152,6 +153,7 @@ ExtensionDeserializer KHR::GetKHRExtensionDeserializer()
     extensionDeserializer.AddHandler<DracoMeshCompression, MeshPrimitive>(DRACOMESHCOMPRESSION_NAME, DeserializeDracoMeshCompression);
     extensionDeserializer.AddHandler<TextureTransform, TextureInfo>(TEXTURETRANSFORM_NAME, DeserializeTextureTransform);
     extensionDeserializer.AddHandler<TextureTransform, Material::NormalTextureInfo>(TEXTURETRANSFORM_NAME, DeserializeTextureTransform);
+    extensionDeserializer.AddHandler<TextureTransform, Material::OcclusionTextureInfo>(TEXTURETRANSFORM_NAME, DeserializeTextureTransform);
     return extensionDeserializer;
 }
 


### PR DESCRIPTION
Texture transforms weren't serializing because the normalTexture uses a different type from other textureInfo properties.