### PR TITLE
Implement generalized float accessor data decoding

### DIFF
--- a/GLTFSDK.Shared.CPP/GLTFSDK.Shared.CPP.vcxitems
+++ b/GLTFSDK.Shared.CPP/GLTFSDK.Shared.CPP.vcxitems
@@ -24,6 +24,7 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Source\ExtensionsKHR.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Source\GLBResourceReader.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Source\GLBResourceWriter.cpp" />
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Source\GLTFResourceReader.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Source\GLTFResourceWriter.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Source\Math.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Source\MeshPrimitiveUtils.cpp" />

--- a/GLTFSDK.Shared.CPP/GLTFSDK.Shared.CPP.vcxitems.filters
+++ b/GLTFSDK.Shared.CPP/GLTFSDK.Shared.CPP.vcxitems.filters
@@ -51,6 +51,9 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Source\GLBResourceWriter.cpp">
       <Filter>Source Files\GLTFSDK</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Source\GLTFResourceReader.cpp">
+      <Filter>Source Files\GLTFSDK</Filter>
+    </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\GLTFSDK\Source\GLTFResourceWriter.cpp">
       <Filter>Source Files\GLTFSDK</Filter>
     </ClCompile>

--- a/GLTFSDK.Test/Source/AnimationUtilsTests.cpp
+++ b/GLTFSDK.Test/Source/AnimationUtilsTests.cpp
@@ -53,7 +53,10 @@ namespace Microsoft
 
                     auto componentType = kComponentTypeMap.find(std::type_index(typeid(T)));
                     Assert::IsTrue(componentType != kComponentTypeMap.end(), L"ComponentType not found");
-                    auto accessor = bufferBuilder.AddAccessor(input, { TYPE_SCALAR, componentType->second });
+
+                    bool normalized = (componentType->second != COMPONENT_FLOAT);
+
+                    auto accessor = bufferBuilder.AddAccessor(input, { TYPE_SCALAR, componentType->second, normalized });
 
                     Document doc;
                     bufferBuilder.Output(doc);
@@ -99,7 +102,10 @@ namespace Microsoft
 
                     auto componentType = kComponentTypeMap.find(std::type_index(typeid(T)));
                     Assert::IsTrue(componentType != kComponentTypeMap.end(), L"ComponentType not found");
-                    auto accessor = bufferBuilder.AddAccessor(input, { TYPE_VEC4, componentType->second });
+
+                    bool normalized = (componentType->second != COMPONENT_FLOAT);
+
+                    auto accessor = bufferBuilder.AddAccessor(input, { TYPE_VEC4, componentType->second, normalized });
 
                     Document doc;
                     bufferBuilder.Output(doc);

--- a/GLTFSDK.Test/Source/AnimationUtilsTests.cpp
+++ b/GLTFSDK.Test/Source/AnimationUtilsTests.cpp
@@ -10,6 +10,7 @@
 #include <GLTFSDK/GLTF.h>
 #include <GLTFSDK/GLTFResourceReader.h>
 #include <GLTFSDK/GLTFResourceWriter.h>
+#include <GLTFSDK/ResourceReaderUtils.h>
 
 #include "TestUtils.h"
 
@@ -46,9 +47,9 @@ namespace Microsoft
                     std::vector<float> expectedOutput;
                     for (auto& v : testValues)
                     {
-                        auto c = AnimationUtils::FloatToComponent<T>(v);
+                        auto c = FloatToComponent<T>(v);
                         input.push_back(c);
-                        expectedOutput.push_back(AnimationUtils::ComponentToFloat(c));
+                        expectedOutput.push_back(ComponentToFloat(c));
                     }
 
                     auto componentType = kComponentTypeMap.find(std::type_index(typeid(T)));
@@ -95,9 +96,9 @@ namespace Microsoft
                     std::vector<float> expectedOutput;
                     for (auto& v : testValues)
                     {
-                        auto c = AnimationUtils::FloatToComponent<T>(v);
+                        auto c = FloatToComponent<T>(v);
                         input.push_back(c);
-                        expectedOutput.push_back(AnimationUtils::ComponentToFloat(c));
+                        expectedOutput.push_back(ComponentToFloat(c));
                     }
 
                     auto componentType = kComponentTypeMap.find(std::type_index(typeid(T)));

--- a/GLTFSDK.Test/Source/GLTFResourceReaderTests.cpp
+++ b/GLTFSDK.Test/Source/GLTFResourceReaderTests.cpp
@@ -576,6 +576,228 @@ namespace Microsoft
 
                     Assert::IsTrue(output == expectedReadOutput);
                 }
+
+                GLTFSDK_TEST_METHOD(GLTFResourceReaderTests, TestReadFloatData)
+                {
+                    auto readerWriter = std::make_shared<const StreamReaderWriter>();
+                    auto bufferBuilder = BufferBuilder(std::make_unique<GLTFResourceWriter>(readerWriter));
+
+                    bufferBuilder.AddBuffer();
+                    bufferBuilder.AddBufferView(BufferViewTarget::ARRAY_BUFFER);
+
+                    std::vector<float> values = { 0.f, 1.f, -0.125f };
+                    auto accessor = bufferBuilder.AddAccessor(values, { TYPE_SCALAR, COMPONENT_FLOAT });
+
+                    Document doc;
+                    bufferBuilder.Output(doc);
+
+                    GLTFResourceReader reader(readerWriter);
+                    auto data = reader.ReadFloatData(doc, accessor);
+
+                    Assert::AreEqual<size_t>(3U, data.size());
+                    Assert::AreEqual<float>(data[0], 0.f);
+                    Assert::AreEqual<float>(data[1], 1.f);
+                    Assert::AreEqual<float>(data[2], -0.125f);
+                }
+
+                GLTFSDK_TEST_METHOD(GLTFResourceReaderTests, TestReadFloatData_U8)
+                {
+                    auto readerWriter = std::make_shared<const StreamReaderWriter>();
+                    auto bufferBuilder = BufferBuilder(std::make_unique<GLTFResourceWriter>(readerWriter));
+
+                    bufferBuilder.AddBuffer();
+                    bufferBuilder.AddBufferView(BufferViewTarget::ARRAY_BUFFER);
+
+                    std::vector<uint8_t> values = { 0, 1, 255 };
+                    auto accessor = bufferBuilder.AddAccessor(values, { TYPE_SCALAR, COMPONENT_UNSIGNED_BYTE });
+
+                    Document doc;
+                    bufferBuilder.Output(doc);
+
+                    GLTFResourceReader reader(readerWriter);
+                    auto data = reader.ReadFloatData(doc, accessor);
+
+                    Assert::AreEqual<size_t>(3U, data.size());
+                    Assert::AreEqual<float>(data[0], 0.f);
+                    Assert::AreEqual<float>(data[1], 1.f);
+                    Assert::AreEqual<float>(data[2], 255.f);
+                }
+
+                GLTFSDK_TEST_METHOD(GLTFResourceReaderTests, TestReadFloatData_U8N)
+                {
+                    auto readerWriter = std::make_shared<const StreamReaderWriter>();
+                    auto bufferBuilder = BufferBuilder(std::make_unique<GLTFResourceWriter>(readerWriter));
+
+                    bufferBuilder.AddBuffer();
+                    bufferBuilder.AddBufferView(BufferViewTarget::ARRAY_BUFFER);
+
+                    std::vector<uint8_t> values = { 0, 1, 255 };
+                    auto accessor = bufferBuilder.AddAccessor(values, { TYPE_SCALAR, COMPONENT_UNSIGNED_BYTE, true });
+
+                    Document doc;
+                    bufferBuilder.Output(doc);
+
+                    GLTFResourceReader reader(readerWriter);
+                    auto data = reader.ReadFloatData(doc, accessor);
+
+                    Assert::AreEqual<size_t>(3U, data.size());
+                    Assert::AreEqual<float>(data[0], 0.f);
+                    Assert::AreEqual<float>(data[1], 1.f / 255.f);
+                    Assert::AreEqual<float>(data[2], 1.f);
+                }
+
+                GLTFSDK_TEST_METHOD(GLTFResourceReaderTests, TestReadFloatData_S8)
+                {
+                    auto readerWriter = std::make_shared<const StreamReaderWriter>();
+                    auto bufferBuilder = BufferBuilder(std::make_unique<GLTFResourceWriter>(readerWriter));
+
+                    bufferBuilder.AddBuffer();
+                    bufferBuilder.AddBufferView(BufferViewTarget::ARRAY_BUFFER);
+
+                    std::vector<int8_t> values = { 0, 1, -1, 127, -127, -128 };
+                    auto accessor = bufferBuilder.AddAccessor(values, { TYPE_SCALAR, COMPONENT_BYTE });
+
+                    Document doc;
+                    bufferBuilder.Output(doc);
+
+                    GLTFResourceReader reader(readerWriter);
+                    auto data = reader.ReadFloatData(doc, accessor);
+
+                    Assert::AreEqual<size_t>(6U, data.size());
+                    Assert::AreEqual<float>(data[0], 0.f);
+                    Assert::AreEqual<float>(data[1], 1.f);
+                    Assert::AreEqual<float>(data[2], -1.f);
+                    Assert::AreEqual<float>(data[3], 127.f);
+                    Assert::AreEqual<float>(data[4], -127.f);
+                    Assert::AreEqual<float>(data[5], -128.f);
+                }
+
+                GLTFSDK_TEST_METHOD(GLTFResourceReaderTests, TestReadFloatData_S8N)
+                {
+                    auto readerWriter = std::make_shared<const StreamReaderWriter>();
+                    auto bufferBuilder = BufferBuilder(std::make_unique<GLTFResourceWriter>(readerWriter));
+
+                    bufferBuilder.AddBuffer();
+                    bufferBuilder.AddBufferView(BufferViewTarget::ARRAY_BUFFER);
+
+                    std::vector<int8_t> values = { 0, 1, -1, 127, -127, -128 };
+                    auto accessor = bufferBuilder.AddAccessor(values, { TYPE_SCALAR, COMPONENT_BYTE, true });
+
+                    Document doc;
+                    bufferBuilder.Output(doc);
+
+                    GLTFResourceReader reader(readerWriter);
+                    auto data = reader.ReadFloatData(doc, accessor);
+
+                    Assert::AreEqual<size_t>(6U, data.size());
+                    Assert::AreEqual<float>(data[0], 0.f);
+                    Assert::AreEqual<float>(data[1], 1.f / 127.f);
+                    Assert::AreEqual<float>(data[2], -1.f / 127.f);
+                    Assert::AreEqual<float>(data[3], 1.f);
+                    Assert::AreEqual<float>(data[4], -1.f);
+                    Assert::AreEqual<float>(data[5], -1.f);
+                }
+
+                GLTFSDK_TEST_METHOD(GLTFResourceReaderTests, TestReadFloatData_U16)
+                {
+                    auto readerWriter = std::make_shared<const StreamReaderWriter>();
+                    auto bufferBuilder = BufferBuilder(std::make_unique<GLTFResourceWriter>(readerWriter));
+
+                    bufferBuilder.AddBuffer();
+                    bufferBuilder.AddBufferView(BufferViewTarget::ARRAY_BUFFER);
+
+                    std::vector<uint16_t> values = { 0, 1, 255, 65535 };
+                    auto accessor = bufferBuilder.AddAccessor(values, { TYPE_SCALAR, COMPONENT_UNSIGNED_SHORT });
+
+                    Document doc;
+                    bufferBuilder.Output(doc);
+
+                    GLTFResourceReader reader(readerWriter);
+                    auto data = reader.ReadFloatData(doc, accessor);
+
+                    Assert::AreEqual<size_t>(4U, data.size());
+                    Assert::AreEqual<float>(data[0], 0.f);
+                    Assert::AreEqual<float>(data[1], 1.f);
+                    Assert::AreEqual<float>(data[2], 255.f);
+                    Assert::AreEqual<float>(data[3], 65535.f);
+                }
+
+                GLTFSDK_TEST_METHOD(GLTFResourceReaderTests, TestReadFloatData_U16N)
+                {
+                    auto readerWriter = std::make_shared<const StreamReaderWriter>();
+                    auto bufferBuilder = BufferBuilder(std::make_unique<GLTFResourceWriter>(readerWriter));
+
+                    bufferBuilder.AddBuffer();
+                    bufferBuilder.AddBufferView(BufferViewTarget::ARRAY_BUFFER);
+
+                    std::vector<uint16_t> values = { 0, 1, 255, 65535 };
+                    auto accessor = bufferBuilder.AddAccessor(values, { TYPE_SCALAR, COMPONENT_UNSIGNED_SHORT, true });
+
+                    Document doc;
+                    bufferBuilder.Output(doc);
+
+                    GLTFResourceReader reader(readerWriter);
+                    auto data = reader.ReadFloatData(doc, accessor);
+
+                    Assert::AreEqual<size_t>(4U, data.size());
+                    Assert::AreEqual<float>(data[0], 0.f);
+                    Assert::AreEqual<float>(data[1], 1.f / 65535.f);
+                    Assert::AreEqual<float>(data[2], 255.f / 65535.f);
+                    Assert::AreEqual<float>(data[3], 1.f);
+                }
+
+                GLTFSDK_TEST_METHOD(GLTFResourceReaderTests, TestReadFloatData_S16)
+                {
+                    auto readerWriter = std::make_shared<const StreamReaderWriter>();
+                    auto bufferBuilder = BufferBuilder(std::make_unique<GLTFResourceWriter>(readerWriter));
+
+                    bufferBuilder.AddBuffer();
+                    bufferBuilder.AddBufferView(BufferViewTarget::ARRAY_BUFFER);
+
+                    std::vector<int16_t> values = { 0, 1, -1, 32767, -32767, -32768 };
+                    auto accessor = bufferBuilder.AddAccessor(values, { TYPE_SCALAR, COMPONENT_SHORT });
+
+                    Document doc;
+                    bufferBuilder.Output(doc);
+
+                    GLTFResourceReader reader(readerWriter);
+                    auto data = reader.ReadFloatData(doc, accessor);
+
+                    Assert::AreEqual<size_t>(6U, data.size());
+                    Assert::AreEqual<float>(data[0], 0.f);
+                    Assert::AreEqual<float>(data[1], 1.f);
+                    Assert::AreEqual<float>(data[2], -1.f);
+                    Assert::AreEqual<float>(data[3], 32767.f);
+                    Assert::AreEqual<float>(data[4], -32767.f);
+                    Assert::AreEqual<float>(data[5], -32768.f);
+                }
+
+                GLTFSDK_TEST_METHOD(GLTFResourceReaderTests, TestReadFloatData_S16N)
+                {
+                    auto readerWriter = std::make_shared<const StreamReaderWriter>();
+                    auto bufferBuilder = BufferBuilder(std::make_unique<GLTFResourceWriter>(readerWriter));
+
+                    bufferBuilder.AddBuffer();
+                    bufferBuilder.AddBufferView(BufferViewTarget::ARRAY_BUFFER);
+
+                    std::vector<int16_t> values = { 0, 1, -1, 32767, -32767, -32768 };
+                    auto accessor = bufferBuilder.AddAccessor(values, { TYPE_SCALAR, COMPONENT_SHORT, true });
+
+                    Document doc;
+                    bufferBuilder.Output(doc);
+
+                    GLTFResourceReader reader(readerWriter);
+                    auto data = reader.ReadFloatData(doc, accessor);
+
+                    Assert::AreEqual<size_t>(6U, data.size());
+                    Assert::AreEqual<float>(data[0], 0.f);
+                    Assert::AreEqual<float>(data[1], 1.f / 32767.f);
+                    Assert::AreEqual<float>(data[2], -1.f / 32767.f);
+                    Assert::AreEqual<float>(data[3], 1.f);
+                    Assert::AreEqual<float>(data[4], -1.f);
+                    Assert::AreEqual<float>(data[5], -1.f);
+                }
+
             };
         }
     }

--- a/GLTFSDK/Inc/GLTFSDK/AnimationUtils.h
+++ b/GLTFSDK/Inc/GLTFSDK/AnimationUtils.h
@@ -4,8 +4,6 @@
 #pragma once
 
 #include <vector>
-#include <algorithm>
-#include <cmath>
 
 namespace Microsoft
 {
@@ -36,24 +34,6 @@ namespace Microsoft
 
             std::vector<float> GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
             std::vector<float> GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
-
-            //  Conversions of normalized component types to/from floats are explicitly defined in the 2.0 spec
-            inline float ComponentToFloat(const float w)   { return w; }
-            inline float ComponentToFloat(const int8_t w)  { return std::max(static_cast<float>(w) / 127.0f, -1.0f); }
-            inline float ComponentToFloat(const uint8_t w) { return static_cast<float>(w) / 255.0f; }
-            inline float ComponentToFloat(const int16_t w) { return std::max(static_cast<float>(w) / 32767.0f, -1.0f); }
-            inline float ComponentToFloat(const uint16_t w){ return static_cast<float>(w) / 65535.0f; }
-
-            template<typename T>
-            inline T FloatToComponent(const float f)
-            {
-                static_assert(std::is_same<float, T>::value, "Microsoft::glTF::AnimationUtils::FloatToComponent: expecting float template type");
-                return f;
-            }
-            template<> inline int8_t   FloatToComponent<int8_t>(const float f)  { return static_cast<int8_t>(std::round(f*127.0f)); }
-            template<> inline uint8_t  FloatToComponent<uint8_t>(const float f) { return static_cast<uint8_t>(std::round(f*255.0f)); }
-            template<> inline int16_t  FloatToComponent<int16_t>(const float f) { return static_cast<int16_t>(std::round(f*32767.0f)); }
-            template<> inline uint16_t FloatToComponent<uint16_t>(const float f){ return static_cast<uint16_t>(std::round(f*65535.0f)); }
         };
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
@@ -110,8 +110,6 @@ namespace Microsoft
                 return ReadAccessor<T>(gltfDocument, accessor);
             }
 
-            std::vector<float> ReadFloatData(const Document& gltfDocument, const Accessor& accessor) const;
-
             template<typename T>
             std::vector<T> ReadBinaryData(const Document& document, const BufferView& bufferView) const
             {
@@ -124,6 +122,8 @@ namespace Microsoft
 
                 return ReadBinaryData<T>(buffer, bufferView.byteOffset, count);
             }
+
+            std::vector<float> ReadFloatData(const Document& gltfDocument, const Accessor& accessor) const;
 
         protected:
             template<typename T>

--- a/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
@@ -110,6 +110,8 @@ namespace Microsoft
                 return ReadAccessor<T>(gltfDocument, accessor);
             }
 
+            std::vector<float> ReadFloatData(const Document& gltfDocument, const Accessor& accessor) const;
+
             template<typename T>
             std::vector<T> ReadBinaryData(const Document& document, const BufferView& bufferView) const
             {

--- a/GLTFSDK/Inc/GLTFSDK/ResourceReaderUtils.h
+++ b/GLTFSDK/Inc/GLTFSDK/ResourceReaderUtils.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <vector>
+#include <cmath>
 
 namespace Microsoft
 {
@@ -216,5 +217,23 @@ namespace Microsoft
 
             return IsUriBase64(uri, itBegin, itEnd);
         }
+
+        // Conversions of normalized component types to/from floats are explicitly defined in the 2.0 spec
+        inline float ComponentToFloat(const float w)   { return w; }
+        inline float ComponentToFloat(const int8_t w)  { return std::max(static_cast<float>(w) / 127.0f, -1.0f); }
+        inline float ComponentToFloat(const uint8_t w) { return static_cast<float>(w) / 255.0f; }
+        inline float ComponentToFloat(const int16_t w) { return std::max(static_cast<float>(w) / 32767.0f, -1.0f); }
+        inline float ComponentToFloat(const uint16_t w){ return static_cast<float>(w) / 65535.0f; }
+
+        template<typename T>
+        inline T FloatToComponent(const float f)
+        {
+            static_assert(std::is_same<float, T>::value, "Microsoft::glTF::FloatToComponent: expecting float template type");
+            return f;
+        }
+        template<> inline int8_t   FloatToComponent<int8_t>(const float f)  { return static_cast<int8_t>(std::round(f*127.0f)); }
+        template<> inline uint8_t  FloatToComponent<uint8_t>(const float f) { return static_cast<uint8_t>(std::round(f*255.0f)); }
+        template<> inline int16_t  FloatToComponent<int16_t>(const float f) { return static_cast<int16_t>(std::round(f*32767.0f)); }
+        template<> inline uint16_t FloatToComponent<uint16_t>(const float f){ return static_cast<uint16_t>(std::round(f*65535.0f)); }
     }
 }

--- a/GLTFSDK/Source/AnimationUtils.cpp
+++ b/GLTFSDK/Source/AnimationUtils.cpp
@@ -8,23 +8,6 @@
 
 using namespace Microsoft::glTF;
 
-namespace
-{
-    template<typename T>
-    std::vector<float> GetDataFloats(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
-    {
-        std::vector<T> rawData = reader.ReadBinaryData<T>(doc, accessor);
-
-        std::vector<float> floatData;
-        floatData.reserve(rawData.size());
-
-        std::transform(rawData.begin(), rawData.end(), std::back_inserter(floatData),
-            [](T value) -> float { return AnimationUtils::ComponentToFloat(value); });
-
-        return floatData;
-    }
-}
-
 std::vector<float> AnimationUtils::GetKeyframeTimes(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
 {
     if (accessor.type != TYPE_SCALAR)
@@ -95,21 +78,7 @@ std::vector<float> AnimationUtils::GetRotations(const Document& doc, const GLTFR
         throw GLTFException("Invalid type for rotations accessor " + accessor.id);
     }
 
-    switch (accessor.componentType)
-    {
-    case COMPONENT_FLOAT:
-        return reader.ReadBinaryData<float>(doc, accessor);
-    case COMPONENT_BYTE:
-        return GetDataFloats<int8_t>(doc, reader, accessor);
-    case COMPONENT_UNSIGNED_BYTE:
-        return GetDataFloats<uint8_t>(doc, reader, accessor);
-    case COMPONENT_SHORT:
-        return GetDataFloats<int16_t>(doc, reader, accessor);
-    case COMPONENT_UNSIGNED_SHORT:
-        return GetDataFloats<uint16_t>(doc, reader, accessor);
-    default:
-        throw GLTFException("Invalid componentType for rotations accessor " + accessor.id);
-    }
+    return reader.ReadFloatData(doc, accessor);
 }
 
 std::vector<float> AnimationUtils::GetRotations(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler)
@@ -146,21 +115,7 @@ std::vector<float> AnimationUtils::GetMorphWeights(const Document& doc, const GL
         throw GLTFException("Invalid type for weights accessor " + accessor.id);
     }
 
-    switch (accessor.componentType)
-    {
-    case COMPONENT_FLOAT: 
-        return reader.ReadBinaryData<float>(doc, accessor);
-    case COMPONENT_BYTE:
-        return GetDataFloats<int8_t>(doc, reader, accessor);
-    case COMPONENT_UNSIGNED_BYTE:
-        return GetDataFloats<uint8_t>(doc, reader, accessor);
-    case COMPONENT_SHORT:
-        return GetDataFloats<int16_t>(doc, reader, accessor);
-    case COMPONENT_UNSIGNED_SHORT:
-        return GetDataFloats<uint16_t>(doc, reader, accessor);
-    default:
-        throw GLTFException("Invalid componentType for weights accessor " + accessor.id);
-    }
+    return reader.ReadFloatData(doc, accessor);
 }
 
 std::vector<float> AnimationUtils::GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler)

--- a/GLTFSDK/Source/GLTFResourceReader.cpp
+++ b/GLTFSDK/Source/GLTFResourceReader.cpp
@@ -8,13 +8,13 @@ using namespace Microsoft::glTF;
 namespace
 {
 	// Conversions of normalized component types to/from floats are explicitly defined in the 2.0 spec
-	inline float ComponentToFloat(const int8_t w)  { return std::max(static_cast<float>(w) / 127.0f, -1.0f); }
-	inline float ComponentToFloat(const uint8_t w) { return static_cast<float>(w) / 255.0f; }
-	inline float ComponentToFloat(const int16_t w) { return std::max(static_cast<float>(w) / 32767.0f, -1.0f); }
-	inline float ComponentToFloat(const uint16_t w){ return static_cast<float>(w) / 65535.0f; }
+	float ComponentToFloat(const int8_t w)  { return std::max(static_cast<float>(w) / 127.0f, -1.0f); }
+	float ComponentToFloat(const uint8_t w) { return static_cast<float>(w) / 255.0f; }
+	float ComponentToFloat(const int16_t w) { return std::max(static_cast<float>(w) / 32767.0f, -1.0f); }
+	float ComponentToFloat(const uint16_t w){ return static_cast<float>(w) / 65535.0f; }
 
 	template<typename T>
-	std::vector<float> DecodeFloats(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
+	std::vector<float> DecodeToFloats(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
 	{
 	    std::vector<T> rawData = reader.ReadBinaryData<T>(doc, accessor);
 
@@ -40,16 +40,16 @@ std::vector<float> GLTFResourceReader::ReadFloatData(const Document& gltfDocumen
 	switch (accessor.componentType)
 	{
 	case COMPONENT_BYTE:
-		return DecodeFloats<int8_t>(gltfDocument, *this, accessor);
+		return DecodeToFloats<int8_t>(gltfDocument, *this, accessor);
 
 	case COMPONENT_UNSIGNED_BYTE:
-		return DecodeFloats<uint8_t>(gltfDocument, *this, accessor);
+		return DecodeToFloats<uint8_t>(gltfDocument, *this, accessor);
 
 	case COMPONENT_SHORT:
-		return DecodeFloats<int16_t>(gltfDocument, *this, accessor);
+		return DecodeToFloats<int16_t>(gltfDocument, *this, accessor);
 
 	case COMPONENT_UNSIGNED_SHORT:
-		return DecodeFloats<uint16_t>(gltfDocument, *this, accessor);
+		return DecodeToFloats<uint16_t>(gltfDocument, *this, accessor);
 
 	case COMPONENT_FLOAT:
 		return ReadBinaryData<float>(gltfDocument, accessor);

--- a/GLTFSDK/Source/GLTFResourceReader.cpp
+++ b/GLTFSDK/Source/GLTFResourceReader.cpp
@@ -22,8 +22,15 @@ namespace
 	    std::vector<float> floatData;
 	    floatData.reserve(rawData.size());
 
-	    std::transform(rawData.begin(), rawData.end(), std::back_inserter(floatData),
-	        [](T value) -> float { return ComponentToFloat(value); });
+		if (accessor.normalized)
+		{
+			std::transform(rawData.begin(), rawData.end(), std::back_inserter(floatData),
+				[](T value) -> float { return ComponentToFloat(value); });
+		}
+		else
+		{
+			std::copy(rawData.begin(), rawData.end(), std::back_inserter(floatData));
+		}
 
 	    return floatData;
 	}

--- a/GLTFSDK/Source/GLTFResourceReader.cpp
+++ b/GLTFSDK/Source/GLTFResourceReader.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include <GLTFSDK/GLTFResourceReader.h>
+
+using namespace Microsoft::glTF;
+
+namespace
+{
+	// Conversions of normalized component types to/from floats are explicitly defined in the 2.0 spec
+	inline float ComponentToFloat(const float w)   { return w; }
+	inline float ComponentToFloat(const int8_t w)  { return std::max(static_cast<float>(w) / 127.0f, -1.0f); }
+	inline float ComponentToFloat(const uint8_t w) { return static_cast<float>(w) / 255.0f; }
+	inline float ComponentToFloat(const int16_t w) { return std::max(static_cast<float>(w) / 32767.0f, -1.0f); }
+	inline float ComponentToFloat(const uint16_t w){ return static_cast<float>(w) / 65535.0f; }
+
+	template<typename T>
+	std::vector<float> DecodeFloats(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
+	{
+	    std::vector<T> rawData = reader.ReadBinaryData<T>(doc, accessor);
+
+	    std::vector<float> floatData;
+	    floatData.reserve(rawData.size());
+
+	    std::transform(rawData.begin(), rawData.end(), std::back_inserter(floatData),
+	        [](T value) -> float { return ComponentToFloat(value); });
+
+	    return floatData;
+	}
+}
+
+std::vector<float> GLTFResourceReader::ReadFloatData(const Document& gltfDocument, const Accessor& accessor) const
+{
+	switch (accessor.componentType)
+	{
+	case COMPONENT_BYTE:
+		return DecodeFloats<int8_t>(gltfDocument, *this, accessor);
+
+	case COMPONENT_UNSIGNED_BYTE:
+		return DecodeFloats<uint8_t>(gltfDocument, *this, accessor);
+
+	case COMPONENT_SHORT:
+		return DecodeFloats<int16_t>(gltfDocument, *this, accessor);
+
+	case COMPONENT_UNSIGNED_SHORT:
+		return DecodeFloats<uint16_t>(gltfDocument, *this, accessor);
+
+	case COMPONENT_FLOAT:
+		return ReadBinaryData<float>(gltfDocument, accessor);
+
+	default:
+		throw GLTFException("Unsupported accessor ComponentType");
+	}
+}

--- a/GLTFSDK/Source/GLTFResourceReader.cpp
+++ b/GLTFSDK/Source/GLTFResourceReader.cpp
@@ -2,17 +2,12 @@
 // Licensed under the MIT License.
 
 #include <GLTFSDK/GLTFResourceReader.h>
+#include <GLTFSDK/ResourceReaderUtils.h>
 
 using namespace Microsoft::glTF;
 
 namespace
 {
-    // Conversions of normalized component types to/from floats are explicitly defined in the 2.0 spec
-    float DecodeToFloat(const int8_t w)  { return std::max(static_cast<float>(w) / 127.0f, -1.0f); }
-    float DecodeToFloat(const uint8_t w) { return static_cast<float>(w) / 255.0f; }
-    float DecodeToFloat(const int16_t w) { return std::max(static_cast<float>(w) / 32767.0f, -1.0f); }
-    float DecodeToFloat(const uint16_t w){ return static_cast<float>(w) / 65535.0f; }
-
     template<typename T>
     std::vector<float> DecodeToFloats(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
     {
@@ -24,7 +19,7 @@ namespace
         if (accessor.normalized)
         {
             std::transform(rawData.begin(), rawData.end(), std::back_inserter(floatData),
-                [](T value) -> float { return DecodeToFloat(value); });
+                [](T value) -> float { return ComponentToFloat(value); });
         }
         else
         {

--- a/GLTFSDK/Source/GLTFResourceReader.cpp
+++ b/GLTFSDK/Source/GLTFResourceReader.cpp
@@ -7,54 +7,54 @@ using namespace Microsoft::glTF;
 
 namespace
 {
-	// Conversions of normalized component types to/from floats are explicitly defined in the 2.0 spec
-	float ComponentToFloat(const int8_t w)  { return std::max(static_cast<float>(w) / 127.0f, -1.0f); }
-	float ComponentToFloat(const uint8_t w) { return static_cast<float>(w) / 255.0f; }
-	float ComponentToFloat(const int16_t w) { return std::max(static_cast<float>(w) / 32767.0f, -1.0f); }
-	float ComponentToFloat(const uint16_t w){ return static_cast<float>(w) / 65535.0f; }
+    // Conversions of normalized component types to/from floats are explicitly defined in the 2.0 spec
+    float ComponentToFloat(const int8_t w)  { return std::max(static_cast<float>(w) / 127.0f, -1.0f); }
+    float ComponentToFloat(const uint8_t w) { return static_cast<float>(w) / 255.0f; }
+    float ComponentToFloat(const int16_t w) { return std::max(static_cast<float>(w) / 32767.0f, -1.0f); }
+    float ComponentToFloat(const uint16_t w){ return static_cast<float>(w) / 65535.0f; }
 
-	template<typename T>
-	std::vector<float> DecodeToFloats(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
-	{
-	    std::vector<T> rawData = reader.ReadBinaryData<T>(doc, accessor);
+    template<typename T>
+    std::vector<float> DecodeToFloats(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
+    {
+        std::vector<T> rawData = reader.ReadBinaryData<T>(doc, accessor);
 
-	    std::vector<float> floatData;
-	    floatData.reserve(rawData.size());
+        std::vector<float> floatData;
+        floatData.reserve(rawData.size());
 
-		if (accessor.normalized)
-		{
-			std::transform(rawData.begin(), rawData.end(), std::back_inserter(floatData),
-				[](T value) -> float { return ComponentToFloat(value); });
-		}
-		else
-		{
-			std::copy(rawData.begin(), rawData.end(), std::back_inserter(floatData));
-		}
+        if (accessor.normalized)
+        {
+            std::transform(rawData.begin(), rawData.end(), std::back_inserter(floatData),
+                [](T value) -> float { return ComponentToFloat(value); });
+        }
+        else
+        {
+            std::copy(rawData.begin(), rawData.end(), std::back_inserter(floatData));
+        }
 
-	    return floatData;
-	}
+        return floatData;
+    }
 }
 
 std::vector<float> GLTFResourceReader::ReadFloatData(const Document& gltfDocument, const Accessor& accessor) const
 {
-	switch (accessor.componentType)
-	{
-	case COMPONENT_BYTE:
-		return DecodeToFloats<int8_t>(gltfDocument, *this, accessor);
+    switch (accessor.componentType)
+    {
+    case COMPONENT_BYTE:
+        return DecodeToFloats<int8_t>(gltfDocument, *this, accessor);
 
-	case COMPONENT_UNSIGNED_BYTE:
-		return DecodeToFloats<uint8_t>(gltfDocument, *this, accessor);
+    case COMPONENT_UNSIGNED_BYTE:
+        return DecodeToFloats<uint8_t>(gltfDocument, *this, accessor);
 
-	case COMPONENT_SHORT:
-		return DecodeToFloats<int16_t>(gltfDocument, *this, accessor);
+    case COMPONENT_SHORT:
+        return DecodeToFloats<int16_t>(gltfDocument, *this, accessor);
 
-	case COMPONENT_UNSIGNED_SHORT:
-		return DecodeToFloats<uint16_t>(gltfDocument, *this, accessor);
+    case COMPONENT_UNSIGNED_SHORT:
+        return DecodeToFloats<uint16_t>(gltfDocument, *this, accessor);
 
-	case COMPONENT_FLOAT:
-		return ReadBinaryData<float>(gltfDocument, accessor);
+    case COMPONENT_FLOAT:
+        return ReadBinaryData<float>(gltfDocument, accessor);
 
-	default:
-		throw GLTFException("Unsupported accessor ComponentType");
-	}
+    default:
+        throw GLTFException("Unsupported accessor ComponentType");
+    }
 }

--- a/GLTFSDK/Source/GLTFResourceReader.cpp
+++ b/GLTFSDK/Source/GLTFResourceReader.cpp
@@ -18,12 +18,13 @@ namespace
 
         if (accessor.normalized)
         {
-            std::transform(rawData.begin(), rawData.end(), std::back_inserter(floatData),
-                [](T value) -> float { return ComponentToFloat(value); });
+            for (size_t i = 0; i < rawData.size(); ++i)
+                floatData.push_back(ComponentToFloat(rawData[i]));
         }
         else
         {
-            std::copy(rawData.begin(), rawData.end(), std::back_inserter(floatData));
+            for (size_t i = 0; i < rawData.size(); ++i)
+                floatData.push_back(static_cast<float>(rawData[i]));
         }
 
         return floatData;

--- a/GLTFSDK/Source/GLTFResourceReader.cpp
+++ b/GLTFSDK/Source/GLTFResourceReader.cpp
@@ -8,7 +8,6 @@ using namespace Microsoft::glTF;
 namespace
 {
 	// Conversions of normalized component types to/from floats are explicitly defined in the 2.0 spec
-	inline float ComponentToFloat(const float w)   { return w; }
 	inline float ComponentToFloat(const int8_t w)  { return std::max(static_cast<float>(w) / 127.0f, -1.0f); }
 	inline float ComponentToFloat(const uint8_t w) { return static_cast<float>(w) / 255.0f; }
 	inline float ComponentToFloat(const int16_t w) { return std::max(static_cast<float>(w) / 32767.0f, -1.0f); }

--- a/GLTFSDK/Source/GLTFResourceReader.cpp
+++ b/GLTFSDK/Source/GLTFResourceReader.cpp
@@ -8,10 +8,10 @@ using namespace Microsoft::glTF;
 namespace
 {
     // Conversions of normalized component types to/from floats are explicitly defined in the 2.0 spec
-    float ComponentToFloat(const int8_t w)  { return std::max(static_cast<float>(w) / 127.0f, -1.0f); }
-    float ComponentToFloat(const uint8_t w) { return static_cast<float>(w) / 255.0f; }
-    float ComponentToFloat(const int16_t w) { return std::max(static_cast<float>(w) / 32767.0f, -1.0f); }
-    float ComponentToFloat(const uint16_t w){ return static_cast<float>(w) / 65535.0f; }
+    float DecodeToFloat(const int8_t w)  { return std::max(static_cast<float>(w) / 127.0f, -1.0f); }
+    float DecodeToFloat(const uint8_t w) { return static_cast<float>(w) / 255.0f; }
+    float DecodeToFloat(const int16_t w) { return std::max(static_cast<float>(w) / 32767.0f, -1.0f); }
+    float DecodeToFloat(const uint16_t w){ return static_cast<float>(w) / 65535.0f; }
 
     template<typename T>
     std::vector<float> DecodeToFloats(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
@@ -24,7 +24,7 @@ namespace
         if (accessor.normalized)
         {
             std::transform(rawData.begin(), rawData.end(), std::back_inserter(floatData),
-                [](T value) -> float { return ComponentToFloat(value); });
+                [](T value) -> float { return DecodeToFloat(value); });
         }
         else
         {

--- a/GLTFSDK/Source/MeshPrimitiveUtils.cpp
+++ b/GLTFSDK/Source/MeshPrimitiveUtils.cpp
@@ -88,136 +88,6 @@ namespace
         return colors32;
     }
 
-    std::vector<uint32_t> PackColorsRGBA(const std::vector<uint8_t>& colors)
-    {
-        assert(colors.size() % 4 == 0);
-
-        std::vector<uint32_t> colors32;
-        colors32.reserve(colors.size() / 4);
-
-        for (size_t i = 0; i < colors.size(); i += 4)
-        {
-            uint8_t r = colors[i];
-            uint8_t g = colors[i + 1];
-            uint8_t b = colors[i + 2];
-            uint8_t a = colors[i + 3];
-            uint32_t rgba = ToUint32(r, g, b, a);
-            colors32.push_back(rgba);
-        }
-
-        return colors32;
-    }
-
-    std::vector<uint32_t> PackColorsRGB(const std::vector<uint8_t>& colors)
-    {
-        assert(colors.size() % 3 == 0);
-
-        std::vector<uint32_t> colors32;
-        colors32.reserve(colors.size() / 3);
-
-        for (size_t i = 0; i < colors.size(); i += 3)
-        {
-            uint8_t r = colors[i];
-            uint8_t g = colors[i + 1];
-            uint8_t b = colors[i + 2];
-            uint32_t rgba = ToUint32(r, g, b, 255);
-            colors32.push_back(rgba);
-        }
-
-        return colors32;
-    }
-
-    std::vector<uint32_t> PackColorsRGBA(const std::vector<uint16_t>& colors)
-    {
-        assert(colors.size() % 4 == 0);
-
-        std::vector<uint32_t> colors32;
-        colors32.reserve(colors.size() / 4);
-
-        for (size_t i = 0; i < colors.size(); i += 4)
-        {
-            uint8_t r = ToUint8(colors[i]);
-            uint8_t g = ToUint8(colors[i + 1]);
-            uint8_t b = ToUint8(colors[i + 2]);
-            uint8_t a = ToUint8(colors[i + 3]);
-            uint32_t rgba = ToUint32(r, g, b, a);
-            colors32.push_back(rgba);
-        }
-
-        return colors32;
-    }
-
-    std::vector<uint32_t> PackColorsRGB(const std::vector<uint16_t>& colors)
-    {
-        assert(colors.size() % 3 == 0);
-
-        std::vector<uint32_t> colors32;
-        colors32.reserve(colors.size() / 3);
-
-        for (size_t i = 0; i < colors.size(); i += 3)
-        {
-            uint8_t r = ToUint8(colors[i]);
-            uint8_t g = ToUint8(colors[i + 1]);
-            uint8_t b = ToUint8(colors[i + 2]);
-            uint32_t rgba = ToUint32(r, g, b, 255);
-            colors32.push_back(rgba);
-        }
-
-        return colors32;
-    }
-
-    template<typename T>
-    std::vector<uint32_t> ReadColors(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
-    {
-        std::vector<T> colors = reader.ReadBinaryData<T>(doc, accessor);
-
-        switch (accessor.type)
-        {
-        case TYPE_VEC4:
-            return PackColorsRGBA(colors);
-
-        case TYPE_VEC3:
-            return PackColorsRGB(colors);
-
-        default:
-            throw GLTFException("Invalid type for color accessor " + accessor.id);
-        }
-    }
-
-    std::vector<float> ReadTexCoords(const std::vector<float>&& texcoords)
-    {
-        return std::move(texcoords);
-    }
-
-    std::vector<float> ReadTexCoords(const std::vector<uint8_t>&& texcoords)
-    {
-        std::vector<float> texcoordsFloat;
-        texcoordsFloat.reserve(texcoords.size());
-        for (size_t i = 0; i < texcoords.size(); i++)
-        {
-            texcoordsFloat.push_back(texcoords[i] / FLOAT_UINT8_MAX);
-        }
-        return texcoordsFloat;
-    }
-
-    std::vector<float> ReadTexCoords(const std::vector<uint16_t>&& texcoords)
-    {
-        std::vector<float> texcoordsFloat;
-        texcoordsFloat.reserve(texcoords.size());
-        for (size_t i = 0; i < texcoords.size(); i++)
-        {
-            texcoordsFloat.push_back(texcoords[i] / FLOAT_UINT16_MAX);
-        }
-        return texcoordsFloat;
-    }
-
-    template<typename T>
-    std::vector<float> ReadTexCoords(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
-    {
-        std::vector<T> texcoords = reader.ReadBinaryData<T>(doc, accessor);
-        return ReadTexCoords(std::move(texcoords));
-    }
-
     std::vector<uint32_t> ReadJoints32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
     {
         std::vector<uint8_t> joints = reader.ReadBinaryData<uint8_t>(doc, accessor);
@@ -259,7 +129,7 @@ namespace
         return ReadJoints64(joints);
     }
 
-    std::vector<uint32_t> ReadWeights32(const std::vector<float>&& weights)
+    std::vector<uint32_t> PackWeights32(const std::vector<float>& weights)
     {
         std::vector<uint32_t> weights32;
         weights32.reserve(weights.size() / 4);
@@ -273,45 +143,6 @@ namespace
                     Math::FloatToByte(weights[i + 3])));
         }
         return weights32;
-    }
-
-    std::vector<uint32_t> ReadWeights32(const std::vector<uint8_t>&& weights)
-    {
-        std::vector<uint32_t> weights32;
-        weights32.reserve(weights.size() / 4);
-        for (size_t i = 0; i < weights.size(); i += 4)
-        {
-            weights32.push_back(
-                ToUint32(
-                    weights[i],
-                    weights[i + 1],
-                    weights[i + 2],
-                    weights[i + 3]));
-        }
-        return weights32;
-    }
-
-    std::vector<uint32_t> ReadWeights32(const std::vector<uint16_t>&& weights)
-    {
-        std::vector<uint32_t> weights32;
-        weights32.reserve(weights.size() / 4);
-        for (size_t i = 0; i < weights.size(); i += 4)
-        {
-            weights32.push_back(
-                ToUint32(
-                    ToUint8(weights[i]),
-                    ToUint8(weights[i + 1]),
-                    ToUint8(weights[i + 2]),
-                    ToUint8(weights[i + 3])));
-        }
-        return weights32;
-    }
-
-    template<typename T>
-    std::vector<uint32_t> ReadWeights32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
-    {
-        std::vector<T> weights = reader.ReadBinaryData<T>(doc, accessor);
-        return ReadWeights32(std::move(weights));
     }
 
     template<typename T>
@@ -721,12 +552,7 @@ std::vector<float> MeshPrimitiveUtils::GetPositions(const Document& doc, const G
         throw GLTFException("Invalid type for positions accessor " + positionsAccessor.id);
     }
 
-    if (positionsAccessor.componentType != COMPONENT_FLOAT)
-    {
-        throw GLTFException("Invalid component type for positions accessor " + positionsAccessor.id);
-    }
-
-    return reader.ReadBinaryData<float>(doc, positionsAccessor);
+    return reader.ReadFloatData(doc, positionsAccessor);
 }
 
 std::vector<float> MeshPrimitiveUtils::GetPositions(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
@@ -749,12 +575,7 @@ std::vector<float> MeshPrimitiveUtils::GetNormals(const Document& doc, const GLT
         throw GLTFException("Invalid type for normals accessor " + normalsAccessor.id);
     }
 
-    if (normalsAccessor.componentType != COMPONENT_FLOAT)
-    {
-        throw GLTFException("Invalid component type for normals accessor " + normalsAccessor.id);
-    }
-
-    return reader.ReadBinaryData<float>(doc, normalsAccessor);
+    return reader.ReadFloatData(doc, normalsAccessor);
 }
 
 std::vector<float> MeshPrimitiveUtils::GetNormals(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
@@ -777,12 +598,7 @@ std::vector<float> MeshPrimitiveUtils::GetTangents(const Document& doc, const GL
         throw GLTFException("Invalid type for tangents accessor " + tangentsAccessor.id);
     }
 
-    if (tangentsAccessor.componentType != COMPONENT_FLOAT)
-    {
-        throw GLTFException("Invalid component type for tangents accessor " + tangentsAccessor.id);
-    }
-
-    return reader.ReadBinaryData<float>(doc, tangentsAccessor);
+    return reader.ReadFloatData(doc, tangentsAccessor);
 }
 
 std::vector<float> MeshPrimitiveUtils::GetTangents(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
@@ -799,12 +615,7 @@ std::vector<float> MeshPrimitiveUtils::GetMorphTangents(const Document& doc, con
         throw GLTFException("Invalid type for tangents accessor " + tangentsAccessor.id);
     }
 
-    if (tangentsAccessor.componentType != COMPONENT_FLOAT)
-    {
-        throw GLTFException("Invalid component type for tangents accessor " + tangentsAccessor.id);
-    }
-
-    return reader.ReadBinaryData<float>(doc, tangentsAccessor);
+    return reader.ReadFloatData(doc, tangentsAccessor);
 }
 
 std::vector<float> MeshPrimitiveUtils::GetTangents(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget)
@@ -816,20 +627,12 @@ std::vector<float> MeshPrimitiveUtils::GetTangents(const Document& doc, const GL
 // Texcoords
 std::vector<float> MeshPrimitiveUtils::GetTexCoords(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
 {
-    switch (accessor.componentType)
+    if (accessor.type != TYPE_VEC2)
     {
-    case COMPONENT_FLOAT:
-        return ReadTexCoords<float>(doc, reader, accessor);
-
-    case COMPONENT_UNSIGNED_BYTE:
-        return ReadTexCoords<uint8_t>(doc, reader, accessor);
-
-    case COMPONENT_UNSIGNED_SHORT:
-        return ReadTexCoords<uint16_t>(doc, reader, accessor);
-
-    default:
-        throw GLTFException("Invalid componentType for texcoords accessor " + accessor.id);
+        throw GLTFException("Invalid type for texcoords accessor " + accessor.id);
     }
+
+    return reader.ReadFloatData(doc, accessor);
 }
 
 std::vector<float> MeshPrimitiveUtils::GetTexCoords_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
@@ -847,19 +650,18 @@ std::vector<float> MeshPrimitiveUtils::GetTexCoords_1(const Document& doc, const
 // Colors
 std::vector<uint32_t> MeshPrimitiveUtils::GetColors(const Document& doc, const GLTFResourceReader& reader, const Accessor& colorsAccessor)
 {
-    switch (colorsAccessor.componentType)
+    std::vector<float> colorData = reader.ReadFloatData(doc, colorsAccessor);
+
+    switch (colorsAccessor.type)
     {
-    case COMPONENT_FLOAT:
-        return ReadColors<float>(doc, reader, colorsAccessor);
+    case TYPE_VEC4:
+        return PackColorsRGBA(colorData);
 
-    case COMPONENT_UNSIGNED_BYTE:
-        return ReadColors<uint8_t>(doc, reader, colorsAccessor);
-
-    case COMPONENT_UNSIGNED_SHORT:
-        return ReadColors<uint16_t>(doc, reader, colorsAccessor);
+    case TYPE_VEC3:
+        return PackColorsRGB(colorData);
 
     default:
-        throw GLTFException("Invalid componentType for color accessor " + colorsAccessor.id);
+        throw GLTFException("Invalid type for color accessor " + colorsAccessor.id);
     }
 }
 
@@ -930,20 +732,9 @@ std::vector<uint32_t> MeshPrimitiveUtils::GetJointWeights32(const Document& doc,
         throw GLTFException("Invalid type for weights accessor " + weightsAccessor.id);
     }
 
-    switch (weightsAccessor.componentType)
-    {
-    case COMPONENT_FLOAT:
-        return ReadWeights32<float>(doc, reader, weightsAccessor);
+    std::vector<float> weightsData = reader.ReadFloatData(doc, weightsAccessor);
 
-    case COMPONENT_UNSIGNED_BYTE:
-        return ReadWeights32<uint8_t>(doc, reader, weightsAccessor);
-
-    case COMPONENT_UNSIGNED_SHORT:
-        return ReadWeights32<uint16_t>(doc, reader, weightsAccessor);
-
-    default:
-        throw GLTFException("Invalid componentType for weights accessor " + weightsAccessor.id);
-    }
+    return PackWeights32(weightsData);
 }
 
 std::vector<uint32_t> MeshPrimitiveUtils::GetJointWeights32_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)

--- a/GLTFSDK/Source/MeshPrimitiveUtils.cpp
+++ b/GLTFSDK/Source/MeshPrimitiveUtils.cpp
@@ -599,6 +599,11 @@ std::vector<float> MeshPrimitiveUtils::GetPositions(const Document& doc, const G
         throw GLTFException("Invalid type for positions accessor " + positionsAccessor.id);
     }
 
+    if (positionsAccessor.componentType != COMPONENT_FLOAT)
+    {
+        throw GLTFException("Invalid component type for positions accessor " + positionsAccessor.id);
+    }
+
     return reader.ReadFloatData(doc, positionsAccessor);
 }
 
@@ -620,6 +625,11 @@ std::vector<float> MeshPrimitiveUtils::GetNormals(const Document& doc, const GLT
     if (normalsAccessor.type != TYPE_VEC3)
     {
         throw GLTFException("Invalid type for normals accessor " + normalsAccessor.id);
+    }
+
+    if (normalsAccessor.componentType != COMPONENT_FLOAT)
+    {
+        throw GLTFException("Invalid component type for normals accessor " + normalsAccessor.id);
     }
 
     return reader.ReadFloatData(doc, normalsAccessor);
@@ -645,6 +655,11 @@ std::vector<float> MeshPrimitiveUtils::GetTangents(const Document& doc, const GL
         throw GLTFException("Invalid type for tangents accessor " + tangentsAccessor.id);
     }
 
+    if (tangentsAccessor.componentType != COMPONENT_FLOAT)
+    {
+        throw GLTFException("Invalid component type for tangents accessor " + tangentsAccessor.id);
+    }
+
     return reader.ReadFloatData(doc, tangentsAccessor);
 }
 
@@ -662,6 +677,11 @@ std::vector<float> MeshPrimitiveUtils::GetMorphTangents(const Document& doc, con
         throw GLTFException("Invalid type for tangents accessor " + tangentsAccessor.id);
     }
 
+    if (tangentsAccessor.componentType != COMPONENT_FLOAT)
+    {
+        throw GLTFException("Invalid component type for tangents accessor " + tangentsAccessor.id);
+    }
+
     return reader.ReadFloatData(doc, tangentsAccessor);
 }
 
@@ -677,6 +697,11 @@ std::vector<float> MeshPrimitiveUtils::GetTexCoords(const Document& doc, const G
     if (accessor.type != TYPE_VEC2)
     {
         throw GLTFException("Invalid type for texcoords accessor " + accessor.id);
+    }
+
+    if (accessor.componentType != COMPONENT_FLOAT && accessor.componentType != COMPONENT_UNSIGNED_BYTE && accessor.componentType != COMPONENT_UNSIGNED_SHORT)
+    {
+        throw GLTFException("Invalid component type for texcoords accessor " + accessor.id);
     }
 
     return reader.ReadFloatData(doc, accessor);
@@ -700,6 +725,11 @@ std::vector<uint32_t> MeshPrimitiveUtils::GetColors(const Document& doc, const G
     if (colorsAccessor.type != TYPE_VEC4 && colorsAccessor.type != TYPE_VEC3)
     {
         throw GLTFException("Invalid type for color accessor " + colorsAccessor.id);
+    }
+
+    if (colorsAccessor.componentType != COMPONENT_FLOAT && colorsAccessor.componentType != COMPONENT_UNSIGNED_BYTE && colorsAccessor.componentType != COMPONENT_UNSIGNED_SHORT)
+    {
+        throw GLTFException("Invalid component type for colors accessor " + colorsAccessor.id);
     }
 
     if (colorsAccessor.componentType == COMPONENT_UNSIGNED_BYTE)
@@ -787,6 +817,11 @@ std::vector<uint32_t> MeshPrimitiveUtils::GetJointWeights32(const Document& doc,
     if (weightsAccessor.type != TYPE_VEC4)
     {
         throw GLTFException("Invalid type for weights accessor " + weightsAccessor.id);
+    }
+
+    if (weightsAccessor.componentType != COMPONENT_FLOAT && weightsAccessor.componentType != COMPONENT_UNSIGNED_BYTE && weightsAccessor.componentType != COMPONENT_UNSIGNED_SHORT)
+    {
+        throw GLTFException("Invalid component type for weights accessor " + weightsAccessor.id);
     }
 
     if (weightsAccessor.componentType == COMPONENT_UNSIGNED_BYTE)

--- a/GLTFSDK/Source/MeshPrimitiveUtils.cpp
+++ b/GLTFSDK/Source/MeshPrimitiveUtils.cpp
@@ -50,6 +50,36 @@ namespace
         return std::vector<TOut>(indices.begin(), indices.end());
     }
 
+    std::vector<uint32_t> PackColorsRGBA(const std::vector<float>& colors)
+    {
+        assert(colors.size() % 4 == 0);
+
+        std::vector<uint32_t> colors32;
+        colors32.reserve(colors.size() / 4);
+
+        for (size_t i = 0; i < colors.size(); i += 4)
+        {
+            colors32.push_back(Color4(colors[i], colors[i + 1], colors[i + 2], colors[i + 3]).AsUint32RGBA());
+        }
+
+        return colors32;
+    }
+
+    std::vector<uint32_t> PackColorsRGB(const std::vector<float>& colors)
+    {
+        assert(colors.size() % 3 == 0);
+
+        std::vector<uint32_t> colors32;
+        colors32.reserve(colors.size() / 3);
+
+        for (size_t i = 0; i < colors.size(); i += 3)
+        {
+            colors32.push_back(Color4(colors[i], colors[i + 1], colors[i + 2], 1.0f).AsUint32RGBA());
+        }
+
+        return colors32;
+    }
+
     std::vector<uint32_t> PackColorsRGBA(const std::vector<uint8_t>& colors)
     {
         assert(colors.size() % 4 == 0);
@@ -84,36 +114,6 @@ namespace
             uint8_t b = colors[i + 2];
             uint32_t rgba = ToUint32(r, g, b, 255);
             colors32.push_back(rgba);
-        }
-
-        return colors32;
-    }
-
-    std::vector<uint32_t> PackColorsRGBA(const std::vector<float>& colors)
-    {
-        assert(colors.size() % 4 == 0);
-
-        std::vector<uint32_t> colors32;
-        colors32.reserve(colors.size() / 4);
-
-        for (size_t i = 0; i < colors.size(); i += 4)
-        {
-            colors32.push_back(Color4(colors[i], colors[i + 1], colors[i + 2], colors[i + 3]).AsUint32RGBA());
-        }
-
-        return colors32;
-    }
-
-    std::vector<uint32_t> PackColorsRGB(const std::vector<float>& colors)
-    {
-        assert(colors.size() % 3 == 0);
-
-        std::vector<uint32_t> colors32;
-        colors32.reserve(colors.size() / 3);
-
-        for (size_t i = 0; i < colors.size(); i += 3)
-        {
-            colors32.push_back(Color4(colors[i], colors[i + 1], colors[i + 2], 1.0f).AsUint32RGBA());
         }
 
         return colors32;

--- a/GLTFSDK/Source/MeshPrimitiveUtils.cpp
+++ b/GLTFSDK/Source/MeshPrimitiveUtils.cpp
@@ -14,9 +14,6 @@ using namespace Microsoft::glTF;
 
 namespace
 {
-    const float FLOAT_UINT8_MAX = std::numeric_limits<uint8_t>::max();
-    const float FLOAT_UINT16_MAX = std::numeric_limits<uint16_t>::max();
-
     uint64_t ToUint64(const uint16_t short0, const uint16_t short1, const uint16_t short2, const uint16_t short3)
     {
         return

--- a/GLTFSDK/Source/MeshPrimitiveUtils.cpp
+++ b/GLTFSDK/Source/MeshPrimitiveUtils.cpp
@@ -44,11 +44,6 @@ namespace
             static_cast<uint32_t>(byte0);
     }
 
-    uint8_t ToUint8(const uint16_t value)
-    {
-        return static_cast<uint8_t>(round((value / FLOAT_UINT16_MAX) * FLOAT_UINT8_MAX));
-    }
-
     template<typename TIn, typename TOut>
     std::vector<TOut> ReadIndices(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
     {


### PR DESCRIPTION
This change introduces GLTFResourceReader::ReadFloatData that, in
contrast with ReadBinaryData, doesn't require knowledge of the specific
data type and instead decodes the data into floating-point values in
accordance with ES3 rules that are used by glTF specification for
animation and geometry data.

This makes the code much more concise, because there's no need to
enumerate individual types and implement custom fragile conversions, and
trivially makes the code compatible with  additions to the geometry
encodings provided by KHR_mesh_quantization extension.

Note that I had to fix the animation utils tests that incorrectly created an
unnormalized accessor and relied on animation decoding to always normalize
the data.

Fixes #48.