### PR TITLE
Fix std::min / std::max with Windows.h macro

### DIFF
--- a/GLTFSDK/Inc/GLTFSDK/Math.h
+++ b/GLTFSDK/Inc/GLTFSDK/Math.h
@@ -73,7 +73,7 @@ namespace Microsoft
         {
             template<class T>
             const T& Clamp(const T& v, const T& lo, const T& hi) {
-                return std::min(hi, std::max(v, lo));
+                return (std::min)(hi, (std::max)(v, lo));
             }
 
             // https://en.wikipedia.org/wiki/SRGB#The_reverse_transformation

--- a/GLTFSDK/Inc/GLTFSDK/PBRUtils.h
+++ b/GLTFSDK/Inc/GLTFSDK/PBRUtils.h
@@ -26,7 +26,7 @@ namespace Microsoft
                 const auto g = G(color);
                 const auto b = B(color);
 
-                return std::max(std::max(r, g), b);
+                return (std::max)((std::max)(r, g), b);
             }
 
             // http://www.itu.int/rec/R-REC-BT.601
@@ -119,8 +119,8 @@ namespace Microsoft
             const float metallic = SolveMetallic(dielectricSpecularRed, brightnessDiffuse, brightnessSpecular, oneMinusSpecularStrength);
             const float oneMinusMetallic = 1.0f - metallic;
 
-            const TColor baseColorFromDiffuse = sg.diffuse * (oneMinusSpecularStrength / (1.0f - dielectricSpecularRed) / std::max((oneMinusMetallic), std::numeric_limits<float>::epsilon()));
-            const TColor baseColorFromSpecular = (sg.specular - (DIELECTRIC_SPECULAR<TColor> * (oneMinusMetallic))) * (1.0f / std::max(metallic, std::numeric_limits<float>::epsilon()));
+            const TColor baseColorFromDiffuse = sg.diffuse * (oneMinusSpecularStrength / (1.0f - dielectricSpecularRed) / (std::max)((oneMinusMetallic), std::numeric_limits<float>::epsilon()));
+            const TColor baseColorFromSpecular = (sg.specular - (DIELECTRIC_SPECULAR<TColor> * (oneMinusMetallic))) * (1.0f / (std::max)(metallic, std::numeric_limits<float>::epsilon()));
             const TColor baseColor = TColor::Clamp(TColor::Lerp(baseColorFromDiffuse, baseColorFromSpecular, metallic * metallic), 0.0f, 1.0f);
 
             MetallicRoughnessValueTypeless<TColor> mr;

--- a/GLTFSDK/Inc/GLTFSDK/ResourceReaderUtils.h
+++ b/GLTFSDK/Inc/GLTFSDK/ResourceReaderUtils.h
@@ -220,9 +220,9 @@ namespace Microsoft
 
         // Conversions of normalized component types to/from floats are explicitly defined in the 2.0 spec
         inline float ComponentToFloat(const float w)   { return w; }
-        inline float ComponentToFloat(const int8_t w)  { return std::max(static_cast<float>(w) / 127.0f, -1.0f); }
+        inline float ComponentToFloat(const int8_t w)  { return (std::max)(static_cast<float>(w) / 127.0f, -1.0f); }
         inline float ComponentToFloat(const uint8_t w) { return static_cast<float>(w) / 255.0f; }
-        inline float ComponentToFloat(const int16_t w) { return std::max(static_cast<float>(w) / 32767.0f, -1.0f); }
+        inline float ComponentToFloat(const int16_t w) { return (std::max)(static_cast<float>(w) / 32767.0f, -1.0f); }
         inline float ComponentToFloat(const uint16_t w){ return static_cast<float>(w) / 65535.0f; }
 
         template<typename T>

--- a/GLTFSDK/Source/BufferBuilder.cpp
+++ b/GLTFSDK/Source/BufferBuilder.cpp
@@ -188,7 +188,7 @@ void BufferBuilder::AddAccessors(const void* data, size_t count, size_t byteStri
     size_t alignment = 1;
     for (size_t i = 0; i < descCount; ++i)
     {
-        alignment = std::max(alignment, GetAlignment(pDescs[i]));
+        alignment = (std::max)(alignment, GetAlignment(pDescs[i]));
     }
 
     bufferView.byteStride = byteStride;


### PR DESCRIPTION
When `#define NOMINMAX` is no possible.
For example with MFC.