### PR TITLE
Missing includes for VS2019

### DIFF
--- a/GLTFSDK/Inc/GLTFSDK/Math.h
+++ b/GLTFSDK/Inc/GLTFSDK/Math.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cmath>
+#include <cstdint>
 
 namespace Microsoft
 {

--- a/GLTFSDK/Source/Color.cpp
+++ b/GLTFSDK/Source/Color.cpp
@@ -4,6 +4,7 @@
 #include <GLTFSDK/Color.h>
 
 #include <GLTFSDK/Math.h>
+#include <limits>
 
 using namespace Microsoft::glTF;
 


### PR DESCRIPTION
* Math.h requires cstdint for uint8_t etc
* Color.cpp requires limits for std::numeric_limits