### PR TITLE
Integrating all 59, 60 and 61 reported issues

### DIFF
--- a/GLTFSDK.Samples/CMakeLists.txt
+++ b/GLTFSDK.Samples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 add_subdirectory(Deserialize)
 add_subdirectory(Serialize)

--- a/GLTFSDK.Samples/Deserialize/CMakeLists.txt
+++ b/GLTFSDK.Samples/Deserialize/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
+INCLUDE( CheckCXXCompilerFlag )
+
 project (Deserialize)
 
 include(GLTFPlatform)
@@ -7,6 +9,16 @@ GetGLTFPlatform(Platform)
 file(GLOB source_files
     "${CMAKE_CURRENT_LIST_DIR}/Source/main.cpp"
 )
+
+# Check if the compiler supports c++17 and add flags (to avoid using std::experimental::filesystem)
+CHECK_CXX_COMPILER_FLAG( "-std=c++11" COMPILER_SUPPORTS_CXX17 )
+if (COMPILER_SUPPORTS_CXX17)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+set(STD_FILESYSTEM "stdc++fs")
 
 add_executable(Deserialize ${source_files})
 
@@ -29,6 +41,7 @@ endif()
 
 target_link_libraries(Deserialize
     GLTFSDK
+    ${STD_FILESYSTEM}
 )
 
 CreateGLTFInstallTargets(Deserialize ${Platform})

--- a/GLTFSDK.Samples/Deserialize/Source/main.cpp
+++ b/GLTFSDK.Samples/Deserialize/Source/main.cpp
@@ -6,16 +6,25 @@
 #include <GLTFSDK/GLBResourceReader.h>
 #include <GLTFSDK/Deserialize.h>
 
-// Replace this with <filesystem> (and use std::filesystem rather than
-// std::experimental::filesystem) if your toolchain fully supports C++17
-#include <experimental/filesystem>
-
 #include <fstream>
 #include <sstream>
 #include <iostream>
 
 #include <cassert>
 #include <cstdlib>
+
+//If c++17 is supported
+#if ( __cplusplus >= 201703L )
+    #warning "--- 1 ---"
+    #include <filesystem>
+    namespace FILE_SYSTEM = std::filesystem;
+    using namespace FILE_SYSTEM;
+#else
+    #warning "--- 2 ---"
+    #include <experimental/filesystem>
+    namespace FILE_SYSTEM = std::experimental::filesystem;
+    using namespace FILE_SYSTEM;
+#endif
 
 using namespace Microsoft::glTF;
 
@@ -28,7 +37,7 @@ namespace
     class StreamReader : public IStreamReader
     {
     public:
-        StreamReader(std::experimental::filesystem::path pathBase) : m_pathBase(std::move(pathBase))
+        StreamReader(FILE_SYSTEM::path pathBase) : m_pathBase(std::move(pathBase))
         {
             assert(m_pathBase.has_root_path());
         }
@@ -44,7 +53,7 @@ namespace
             //    if appropriate.
             // 3. Always open the file stream in binary mode. The glTF SDK will handle any text
             //    encoding issues for us.
-            auto streamPath = m_pathBase / std::experimental::filesystem::u8path(filename);
+            auto streamPath = m_pathBase / FILE_SYSTEM::u8path(filename);
             auto stream = std::make_shared<std::ifstream>(streamPath, std::ios_base::binary);
 
             // Check if the stream has no errors and is ready for I/O operations
@@ -57,7 +66,7 @@ namespace
         }
 
     private:
-        std::experimental::filesystem::path m_pathBase;
+        FILE_SYSTEM::path m_pathBase;
     };
 
     // Uses the Document class to print some basic information about various top-level glTF entities
@@ -185,13 +194,13 @@ namespace
         }
     }
 
-    void PrintInfo(const std::experimental::filesystem::path& path)
+    void PrintInfo(const FILE_SYSTEM::path& path)
     {
         // Pass the absolute path, without the filename, to the stream reader
         auto streamReader = std::make_unique<StreamReader>(path.parent_path());
 
-        std::experimental::filesystem::path pathFile = path.filename();
-        std::experimental::filesystem::path pathFileExt = pathFile.extension();
+        FILE_SYSTEM::path pathFile = path.filename();
+        FILE_SYSTEM::path pathFileExt = pathFile.extension();
 
         std::string manifest;
 
@@ -271,11 +280,11 @@ int main(int argc, char* argv[])
             throw std::runtime_error("Unexpected number of command line arguments");
         }
 
-        std::experimental::filesystem::path path = argv[1U];
+        FILE_SYSTEM::path path = argv[1U];
 
         if (path.is_relative())
         {
-            auto pathCurrent = std::experimental::filesystem::current_path();
+            auto pathCurrent = FILE_SYSTEM::current_path();
 
             // Convert the relative path into an absolute path by appending the command line argument to the current path
             pathCurrent /= path;

--- a/GLTFSDK.Samples/Serialize/CMakeLists.txt
+++ b/GLTFSDK.Samples/Serialize/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
+INCLUDE( CheckCXXCompilerFlag )
+
 project (Serialize)
 
 include(GLTFPlatform)
@@ -7,6 +9,16 @@ GetGLTFPlatform(Platform)
 file(GLOB source_files
     "${CMAKE_CURRENT_LIST_DIR}/Source/main.cpp"
 )
+
+# Check if the compiler supports c++17 and add flags (to avoid using std::experimental::filesystem)
+CHECK_CXX_COMPILER_FLAG( "-std=c++11" COMPILER_SUPPORTS_CXX17 )
+if (COMPILER_SUPPORTS_CXX17)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+set(STD_FILESYSTEM "stdc++fs")
 
 add_executable(Serialize ${source_files})
 
@@ -29,6 +41,7 @@ endif()
 
 target_link_libraries(Serialize
     GLTFSDK
+    ${STD_FILESYSTEM}
 )
 
 CreateGLTFInstallTargets(Serialize ${Platform})

--- a/GLTFSDK.Samples/Serialize/Source/main.cpp
+++ b/GLTFSDK.Samples/Serialize/Source/main.cpp
@@ -8,16 +8,23 @@
 #include <GLTFSDK/IStreamWriter.h>
 #include <GLTFSDK/Serialize.h>
 
-// Replace this with <filesystem> (and use std::filesystem rather than
-// std::experimental::filesystem) if your toolchain fully supports C++17
-#include <experimental/filesystem>
-
 #include <fstream>
 #include <sstream>
 #include <iostream>
 
 #include <cassert>
 #include <cstdlib>
+
+//If c++17 is supported
+#if ( __cplusplus >= 201701L )
+    #include <filesystem>
+    namespace FILE_SYSTEM = std::filesystem;
+    using namespace FILE_SYSTEM;
+#else
+    #include <experimental/filesystem>
+    namespace FILE_SYSTEM = std::experimental::filesystem;
+    using namespace FILE_SYSTEM;
+#endif
 
 using namespace Microsoft::glTF;
 
@@ -30,7 +37,7 @@ namespace
     class StreamWriter : public IStreamWriter
     {
     public:
-        StreamWriter(std::experimental::filesystem::path pathBase) : m_pathBase(std::move(pathBase))
+        StreamWriter(FILE_SYSTEM::path pathBase) : m_pathBase(std::move(pathBase))
         {
             assert(m_pathBase.has_root_path());
         }
@@ -46,7 +53,7 @@ namespace
             //    if appropriate.
             // 3. Always open the file stream in binary mode. The glTF SDK will handle any text
             //    encoding issues for us.
-            auto streamPath = m_pathBase / std::experimental::filesystem::u8path(filename);
+            auto streamPath = m_pathBase / FILE_SYSTEM::u8path(filename);
             auto stream = std::make_shared<std::ofstream>(streamPath, std::ios_base::binary);
 
             // Check if the stream has no errors and is ready for I/O operations
@@ -59,7 +66,7 @@ namespace
         }
 
     private:
-        std::experimental::filesystem::path m_pathBase;
+        FILE_SYSTEM::path m_pathBase;
     };
 
     void CreateTriangleResources(Document& document, BufferBuilder& bufferBuilder, std::string& accessorIdIndices, std::string& accessorIdPositions)
@@ -171,13 +178,13 @@ namespace
         document.SetDefaultScene(std::move(scene), AppendIdPolicy::GenerateOnEmpty);
     }
 
-    void SerializeTriangle(const std::experimental::filesystem::path& path)
+    void SerializeTriangle(const FILE_SYSTEM::path& path)
     {
         // Pass the absolute path, without the filename, to the stream writer
         auto streamWriter = std::make_unique<StreamWriter>(path.parent_path());
 
-        std::experimental::filesystem::path pathFile = path.filename();
-        std::experimental::filesystem::path pathFileExt = pathFile.extension();
+        FILE_SYSTEM::path pathFile = path.filename();
+        FILE_SYSTEM::path pathFileExt = pathFile.extension();
 
         auto MakePathExt = [](const std::string& ext)
         {
@@ -261,11 +268,11 @@ int main(int argc, char* argv[])
             throw std::runtime_error("Unexpected number of command line arguments");
         }
 
-        std::experimental::filesystem::path path = argv[1U];
+        FILE_SYSTEM::path path = argv[1U];
 
         if (path.is_relative())
         {
-            auto pathCurrent = std::experimental::filesystem::current_path();
+            auto pathCurrent = FILE_SYSTEM::current_path();
 
             // Convert the relative path into an absolute path by appending the command line argument to the current path
             pathCurrent /= path;

--- a/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
+++ b/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
@@ -85,11 +85,13 @@ namespace Microsoft
             ResourceWriter& GetResourceWriter();
             const ResourceWriter& GetResourceWriter() const;
             bool setCurrentBufferURI ( const std::string &data );
-            Buffer getBuffer ( size_t index ) {
+            Buffer getBuffer ( size_t index )
+            {
                 assert ( index < m_buffers.Size() );
                 return m_buffers [ index ];
             }
-            Accessor getAccessor ( size_t index ) {
+            Accessor getAccessor ( size_t index )
+            {
                 assert ( index < m_accessors.Size() );
                 return m_accessors [ index ];
             }

--- a/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
+++ b/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
@@ -84,7 +84,7 @@ namespace Microsoft
 
             ResourceWriter& GetResourceWriter();
             const ResourceWriter& GetResourceWriter() const;
-            bool setCurrentBufferURI ( const std::string &data )
+            bool setCurrentBufferURI ( const std::string &data );
             Buffer getBuffer ( size_t index ) {
                 assert ( index < m_buffers.Size() );
                 return m_buffers [ index ];

--- a/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
+++ b/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
@@ -84,6 +84,15 @@ namespace Microsoft
 
             ResourceWriter& GetResourceWriter();
             const ResourceWriter& GetResourceWriter() const;
+            bool setCurrentBufferURI ( const std::string &data )
+            Buffer getBuffer ( size_t index ) {
+                assert ( index < m_buffers.Size() );
+                return m_buffers [ index ];
+            }
+            Accessor getAccessor ( size_t index ) {
+                assert ( index < m_accessors.Size() );
+                return m_accessors [ index ];
+            }
 
         private:
             const Accessor& AddAccessor(size_t count, AccessorDesc desc);

--- a/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
+++ b/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
@@ -84,16 +84,16 @@ namespace Microsoft
 
             ResourceWriter& GetResourceWriter();
             const ResourceWriter& GetResourceWriter() const;
-            bool setCurrentBufferURI ( const std::string &data );
-            Buffer getBuffer ( size_t index )
+            bool setCurrentBufferURI(const std::string &data);
+            Buffer getBuffer(size_t index)
             {
-                assert ( index < m_buffers.Size() );
-                return m_buffers [ index ];
+                assert(index < m_buffers.Size());
+                return m_buffers[index];
             }
-            Accessor getAccessor ( size_t index )
+            Accessor getAccessor(size_t index)
             {
-                assert ( index < m_accessors.Size() );
-                return m_accessors [ index ];
+                assert(index < m_accessors.Size());
+                return m_accessors[index];
             }
 
         private:

--- a/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
+++ b/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
@@ -6,6 +6,7 @@
 #include <GLTFSDK/GLTF.h>
 
 #include <functional>
+#include <cassert>
 
 namespace Microsoft
 {

--- a/GLTFSDK/Inc/GLTFSDK/GLTF.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLTF.h
@@ -317,6 +317,9 @@ namespace Microsoft
                     && lhs.name == rhs.name
                     && glTFProperty::Equals(lhs, rhs);
             }
+
+        public:
+            void setName ( std::string newName ) { name = newName; }
         };
 
         struct BufferView : glTFChildOfRootProperty

--- a/GLTFSDK/Inc/GLTFSDK/IndexedContainer.h
+++ b/GLTFSDK/Inc/GLTFSDK/IndexedContainer.h
@@ -269,7 +269,7 @@ namespace Microsoft
             // No using declaration for Append, operator== or operator!= as we don't
             // want to make the base class versions of these functions publically
             // accessible (the mutable versions replace rather than complement them)
-            using IndexedContainer::size;
+            using IndexedContainer<const T>::size;
             using IndexedContainer<const T>::Front;
             using IndexedContainer<const T>::Back;
             using IndexedContainer<const T>::Clear;

--- a/GLTFSDK/Inc/GLTFSDK/IndexedContainer.h
+++ b/GLTFSDK/Inc/GLTFSDK/IndexedContainer.h
@@ -35,6 +35,11 @@ namespace Microsoft
         class IndexedContainer<const T, true>
         {
         public:
+
+            const size_t size() const
+            {
+                return m_elements.size();
+            }
             const T& Front() const
             {
                 return m_elements.front();
@@ -201,6 +206,11 @@ namespace Microsoft
             // T). This means all inherited members must be qualified with 'this->' or 'IndexedContainer<const T>::'
 
         public:
+            size_t size()
+            {
+                return (IndexedContainer::size());
+            }
+
             T& Front()
             {
                 return const_cast<T&>(IndexedContainer<const T>::Front());
@@ -259,6 +269,7 @@ namespace Microsoft
             // No using declaration for Append, operator== or operator!= as we don't
             // want to make the base class versions of these functions publically
             // accessible (the mutable versions replace rather than complement them)
+            using IndexedContainer::size;
             using IndexedContainer<const T>::Front;
             using IndexedContainer<const T>::Back;
             using IndexedContainer<const T>::Clear;

--- a/GLTFSDK/Inc/GLTFSDK/Math.h
+++ b/GLTFSDK/Inc/GLTFSDK/Math.h
@@ -5,6 +5,7 @@
 
 #include <array>
 #include <cmath>
+#include <limits>
 
 namespace Microsoft
 {
@@ -84,7 +85,7 @@ namespace Microsoft
                     return value / 12.92f;
                 }
 
-                return std::powf((value + 0.055f) / 1.055f, 2.4f);
+                return powf((value + 0.055f) / 1.055f, 2.4f);
             }
 
             // https://en.wikipedia.org/wiki/SRGB#The_forward_transformation_.28CIE_XYZ_to_sRGB.29
@@ -95,7 +96,7 @@ namespace Microsoft
                     return value * 12.92f;
                 }
 
-                return 1.055f * std::powf(value, 1.0f / 2.4f) - 0.055f;
+                return 1.055f * powf(value, 1.0f / 2.4f) - 0.055f;
             }
 
             inline float ByteToFloat(uint8_t value)

--- a/GLTFSDK/Inc/GLTFSDK/Version.h
+++ b/GLTFSDK/Inc/GLTFSDK/Version.h
@@ -8,6 +8,12 @@
 
 #include <cstdint>
 
+#ifdef linux
+    //g++ adds -D_GNU_SOURCE and major() is a macro in _GNU_SOURCE (or _BSD_SOURCE)
+    #undef major
+    #undef minor
+#endif
+
 namespace Microsoft
 {
     namespace glTF

--- a/GLTFSDK/Source/BufferBuilder.cpp
+++ b/GLTFSDK/Source/BufferBuilder.cpp
@@ -277,6 +277,15 @@ const ResourceWriter& BufferBuilder::GetResourceWriter() const
     return *m_resourceWriter;
 }
 
+bool BufferBuilder::setCurrentBufferURI ( const std::string &data )
+{
+    assert ( m_buffers.size() > 0 );
+    size_t index = m_buffers.size() - 1;
+    m_buffers [ index ].uri = data;
+    m_buffers [ index ].length = data.length();
+    return true;
+}
+
 const Accessor& BufferBuilder::AddAccessor(size_t count, AccessorDesc desc)
 {
     Buffer& buffer = m_buffers.Back();

--- a/GLTFSDK/Source/BufferBuilder.cpp
+++ b/GLTFSDK/Source/BufferBuilder.cpp
@@ -277,12 +277,12 @@ const ResourceWriter& BufferBuilder::GetResourceWriter() const
     return *m_resourceWriter;
 }
 
-bool BufferBuilder::setCurrentBufferURI ( const std::string &data )
+bool BufferBuilder::setCurrentBufferURI(const std::string &data)
 {
-    assert ( m_buffers.size() > 0 );
-    size_t index = m_buffers.size() - 1;
-    m_buffers [ index ].uri = data;
-    m_buffers [ index ].length = data.length();
+    assert (m_buffers.size() > 0);
+    size_t index = m_buffers.size()-1;
+    m_buffers[index].uri = data;
+    m_buffers[index].length = data.length();
     return true;
 }
 

--- a/GLTFSDK/Source/BufferBuilder.cpp
+++ b/GLTFSDK/Source/BufferBuilder.cpp
@@ -282,7 +282,6 @@ bool BufferBuilder::setCurrentBufferURI(const std::string &data)
     assert (m_buffers.size() > 0);
     size_t index = m_buffers.size()-1;
     m_buffers[index].uri = data;
-    m_buffers[index].length = data.length();
     return true;
 }
 


### PR DESCRIPTION
The commit includes fixes for:
    Support for base64 encoded buffers #59
    Set child name (rootProperty) #60
    Direct access to buffers and accessors #61
