### PR TITLE
Adding iterative parse flag to prevent stack overflow issue

### DIFF
--- a/GLTFSDK/Inc/GLTFSDK/RapidJsonUtils.h
+++ b/GLTFSDK/Inc/GLTFSDK/RapidJsonUtils.h
@@ -17,6 +17,8 @@ Please do not include their headers and this header in the same cpp file.
 #define RAPIDJSON_NAMESPACE_BEGIN  namespace Microsoft { namespace glTF { namespace rapidjson {
 #define RAPIDJSON_NAMESPACE_END }}}
 
+// Adding iterative parse flag to prevent stack overflow issue
+#define RAPIDJSON_PARSE_DEFAULT_FLAGS RAPIDJSON_NAMESPACE::ParseFlag::kParseIterativeFlag
 
 // RapidJSON uses constant if expressions to support multiple platforms
 #pragma warning(push)


### PR DESCRIPTION
There was a security issue found with rapidjson where a crash could be caused by certain strings when operating in the default recursive parse mode.  This PR will set all reading to be done in iterative mode.