### PR TITLE
Fix OOB Writing issue when using sparse accessors

### DIFF
--- a/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
@@ -391,7 +391,10 @@ namespace Microsoft
                 {
                     for (size_t j = 0; j < typeCount; j++)
                     {
-                        baseData[indices[i] * typeCount + j] = values[i * typeCount + j];
+                        // Verify provided index is valid before storing value
+                        if ((indices[i] * typeCount + j) < baseData.size()) {
+                            baseData[indices[i] * typeCount + j] = values[i * typeCount + j];
+                        }
                     }
                 }
             }

--- a/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
@@ -389,10 +389,11 @@ namespace Microsoft
 
                 for (size_t i = 0; i < indices.size(); i++)
                 {
-                    for (size_t j = 0; j < typeCount; j++)
+                    // Verify provided index is valid before storing value
+                    if ((indices[i] * typeCount + (typeCount - 1)) < baseData.size())
                     {
-                        // Verify provided index is valid before storing value
-                        if ((indices[i] * typeCount + j) < baseData.size()) {
+                        for (size_t j = 0; j < typeCount; j++)
+                        {
                             baseData[indices[i] * typeCount + j] = values[i * typeCount + j];
                         }
                     }


### PR DESCRIPTION
This PR contains a fix that checks to see if index data being read from a glTF file that is using sparse accessors is valid.