### PR TITLE
Force udpate for RapidJSON_DIR value

### DIFF
--- a/External/RapidJSON/CMakeLists.txt
+++ b/External/RapidJSON/CMakeLists.txt
@@ -27,7 +27,7 @@ add_subdirectory(${CMAKE_BINARY_DIR}/RapidJSON-src
                  EXCLUDE_FROM_ALL)
 
 # Set the RapidJSONConfig.cmake path and make find_package to work in config mode explicitly.
-set(RapidJSON_DIR "${CMAKE_BINARY_DIR}/RapidJSON-build" CACHE LOCATION "Specific configuration file location")
+set(RapidJSON_DIR "${CMAKE_BINARY_DIR}/RapidJSON-build" CACHE LOCATION "Specific configuration file location" FORCE)
 find_package(RapidJSON REQUIRED CONFIG)
 
 add_library(RapidJSON INTERFACE IMPORTED GLOBAL)


### PR DESCRIPTION
Add FORCE flag to setting of RapidJSON_DIR value in RapidJSON's cmake file because it's getting set incorrectly with the find_package(RapidJSON) line in the primary CMakeLists.txt file