### PR TITLE
Fix case of RapidJSON on cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,12 +53,12 @@ add_subdirectory(GLTFSDK)
 
 if(RapidJSON_FOUND)
     target_include_directories(GLTFSDK
-        PUBLIC $<BUILD_INTERFACE:${RAPIDJSON_INCLUDE_DIRS}>
+        PUBLIC $<BUILD_INTERFACE:${RapidJSON_INCLUDE_DIRS}>
     )
 elseif(TARGET RapidJSON)
-    get_target_property(RAPIDJSON_INCLUDE_DIRS RapidJSON INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(RapidJSON_INCLUDE_DIRS RapidJSON INTERFACE_INCLUDE_DIRECTORIES)
     target_include_directories(GLTFSDK
-        PUBLIC $<BUILD_INTERFACE:${RAPIDJSON_INCLUDE_DIRS}>
+        PUBLIC $<BUILD_INTERFACE:${RapidJSON_INCLUDE_DIRS}>
     )
 endif()
 

--- a/External/RapidJSON/CMakeLists.txt
+++ b/External/RapidJSON/CMakeLists.txt
@@ -27,7 +27,7 @@ add_subdirectory(${CMAKE_BINARY_DIR}/RapidJSON-src
                  EXCLUDE_FROM_ALL)
 
 # Set the RapidJSONConfig.cmake path and make find_package to work in config mode explicitly.
-set(RapidJSON_DIR "${CMAKE_BINARY_DIR}/RapidJSON-build" CACHE LOCATION "Specific configuration file location")
+set(RapidJSON_DIR "${CMAKE_BINARY_DIR}/RapidJSON-build" CACHE LOCATION "Specific configuration file location" FORCE)
 find_package(RapidJSON REQUIRED CONFIG)
 
 add_library(RapidJSON INTERFACE IMPORTED GLOBAL)


### PR DESCRIPTION
This PR fixes the case of RapidJSON to prevent issues when running cmake against an already built repo