### PR TITLE
Krzysztof domanski fix type compare warning

### DIFF
--- a/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
@@ -390,7 +390,7 @@ namespace Microsoft
                 for (size_t i = 0; i < indices.size(); i++)
                 {
                     // Verify provided index is valid before storing value
-                    if ((indices[i] * typeCount + (typeCount - 1)) < static_cast<int>(baseData.size()))
+                    if ((indices[i] * typeCount + (typeCount - 1)) < static_cast<I>(baseData.size()))
                     {
                         for (size_t j = 0; j < typeCount; j++)
                         {


### PR DESCRIPTION
By casting the vector size to an int, there is a "error: comparison between signed and unsigned integer expressions [-Werror=sign-compare]" produced. 

The static cast is technically not needed at all, since all the usages of this private template function specialize it with an unsigned integer, but in order to be future proof just use the type of "indices" in the static cast.