### PR TITLE
Expand ReadSparseBinaryData index check to check for overflow

### DIFF
--- a/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
@@ -389,8 +389,11 @@ namespace Microsoft
 
                 for (size_t i = 0; i < indices.size(); i++)
                 {
+                    // Calculate current index
+                    auto currentIndex = indices[i] * typeCount + (typeCount - 1);
+
                     // Verify provided index is valid before storing value
-                    if ((indices[i] * typeCount + (typeCount - 1)) < static_cast<I>(baseData.size()))
+                    if (currentIndex >= indices[i] && currentIndex < static_cast<I>(baseData.size())) {
                     {
                         for (size_t j = 0; j < typeCount; j++)
                         {

--- a/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
@@ -389,11 +389,9 @@ namespace Microsoft
 
                 for (size_t i = 0; i < indices.size(); i++)
                 {
-                    // Calculate current index
-                    auto currentIndex = indices[i] * typeCount + (typeCount - 1);
-
-                    // Verify provided index is valid before storing value
-                    if (currentIndex >= indices[i] && currentIndex < static_cast<I>(baseData.size()))
+                    assert(baseData.size() == accessor.count * typeCount);
+                    static_assert(sizeof(I) <= sizeof(size_t), "sizeof(I) < sizeof(size_t)");
+                    if (0 <= indices[i] && static_cast<size_t>(indices[i]) < accessor.count)
                     {
                         for (size_t j = 0; j < typeCount; j++)
                         {

--- a/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLTFResourceReader.h
@@ -393,7 +393,7 @@ namespace Microsoft
                     auto currentIndex = indices[i] * typeCount + (typeCount - 1);
 
                     // Verify provided index is valid before storing value
-                    if (currentIndex >= indices[i] && currentIndex < static_cast<I>(baseData.size())) {
+                    if (currentIndex >= indices[i] && currentIndex < static_cast<I>(baseData.size()))
                     {
                         for (size_t j = 0; j < typeCount; j++)
                         {


### PR DESCRIPTION
The index check in ReadSparseBinaryData has been expanded to check that an index isn't a value that was calculated from an value greater than its final calculation (integer overflow).