### PR TITLE
Bugfix/update rapid json

### DIFF
--- a/Build/AzureDevOps/azure-pipelines.yml
+++ b/Build/AzureDevOps/azure-pipelines.yml
@@ -4,64 +4,6 @@
 # https://docs.microsoft.com/azure/devops/pipelines/apps/windows/dot-net
 
 jobs:
-  - job: Windows_VS2017
-
-    pool:
-      vmImage: 'VS2017-Win2016'
-
-    strategy:
-      matrix:
-        Win32-Release:
-          buildPlatform: Win32
-          buildConfiguration: Release
-        Win32-Debug:
-          buildPlatform: Win32
-          buildConfiguration: Debug
-        x64-Release:
-          buildPlatform: x64
-          buildConfiguration: Release
-        x64-Debug:
-          buildPlatform: x64
-          buildConfiguration: Debug
-        ARM-Release:
-          buildPlatform: ARM
-          buildConfiguration: Release
-        ARM-Debug:
-          buildPlatform: ARM
-          buildConfiguration: Debug
-        ARM64-Release:
-          buildPlatform: ARM64
-          buildConfiguration: Release
-        ARM64-Debug:
-          buildPlatform: ARM64
-          buildConfiguration: Debug
-
-    workspace:
-      clean: all
-
-    steps:
-
-    - task: CMake@1
-      inputs:
-        workingDirectory: 'built\Int\cmake_$(buildPlatform)'
-        cmakeArgs: '..\..\.. -G "Visual Studio 15 2017" -A "$(buildPlatform)"'
-
-    - task: CMake@1
-      inputs:
-        workingDirectory: 'built\Int\cmake_$(buildPlatform)'
-        cmakeArgs: '--build . --target install --config $(buildConfiguration) -- /m'
-
-    - script: .\GLTFSDK.Test.exe --gtest_output=xml:GLTFSDK.Test.log
-      workingDirectory: built\Out\windows_$(buildPlatform)\$(buildConfiguration)\GLTFSDK.Test
-      displayName: Running Unit Tests
-      condition: and(succeeded(), in(variables['buildPlatform'], 'Win32', 'x64'))
-
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: built\Out\windows_$(buildPlatform)\$(buildConfiguration)\GLTFSDK.Test\GLTFSDK.Test.log
-      condition: and(succeeded(), in(variables['buildPlatform'], 'Win32', 'x64'))
-
   - job: Windows_VS2019
 
     pool:
@@ -120,165 +62,85 @@ jobs:
         testResultsFiles: built\Out\windows_$(buildPlatform)\$(buildConfiguration)\GLTFSDK.Test\GLTFSDK.Test.log
       condition: and(succeeded(), in(variables['buildPlatform'], 'Win32', 'x64'))
 
-  - job: WindowsVcPkg_VS2017
+  # - job: WindowsVcPkg_VS2019
 
-    pool:
-      vmImage: 'VS2017-Win2016'
+  #   pool:
+  #     vmImage: 'windows-2019'
 
-    strategy:
-      matrix:
-        Win32-Release:
-          buildPlatform: Win32
-          buildConfiguration: Release
-          vcpkgTriplet: x86-windows
-        Win32-Debug:
-          buildPlatform: Win32
-          buildConfiguration: Debug
-          vcpkgTriplet: x86-windows
-        x64-Release:
-          buildPlatform: x64
-          buildConfiguration: Release
-          vcpkgTriplet: x64-windows
-        x64-Debug:
-          buildPlatform: x64
-          buildConfiguration: Debug
-          vcpkgTriplet: x64-windows
-        ARM-Release:
-          buildPlatform: ARM
-          buildConfiguration: Release
-          vcpkgTriplet: arm-windows
-        ARM-Debug:
-          buildPlatform: ARM
-          buildConfiguration: Debug
-          vcpkgTriplet: arm-windows
-        ARM64-Release:
-          buildPlatform: ARM64
-          buildConfiguration: Release
-          vcpkgTriplet: arm64-windows
-        ARM64-Debug:
-          buildPlatform: ARM64
-          buildConfiguration: Debug
-          vcpkgTriplet: arm64-windows
+  #   strategy:
+  #     matrix:
+  #       Win32-Release:
+  #         buildPlatform: Win32
+  #         buildConfiguration: Release
+  #         vcpkgTriplet: x86-windows
+  #       Win32-Debug:
+  #         buildPlatform: Win32
+  #         buildConfiguration: Debug
+  #         vcpkgTriplet: x86-windows
+  #       x64-Release:
+  #         buildPlatform: x64
+  #         buildConfiguration: Release
+  #         vcpkgTriplet: x64-windows
+  #       x64-Debug:
+  #         buildPlatform: x64
+  #         buildConfiguration: Debug
+  #         vcpkgTriplet: x64-windows
+  #       ARM-Release:
+  #         buildPlatform: ARM
+  #         buildConfiguration: Release
+  #         vcpkgTriplet: arm-windows
+  #       ARM-Debug:
+  #         buildPlatform: ARM
+  #         buildConfiguration: Debug
+  #         vcpkgTriplet: arm-windows
+  #       ARM64-Release:
+  #         buildPlatform: ARM64
+  #         buildConfiguration: Release
+  #         vcpkgTriplet: arm64-windows
+  #       ARM64-Debug:
+  #         buildPlatform: ARM64
+  #         buildConfiguration: Debug
+  #         vcpkgTriplet: arm64-windows
 
-    workspace:
-      clean: all
+  #   workspace:
+  #     clean: all
 
-    variables:
-      vcpkgRoot: "C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
+  #   variables:
+  #     vcpkgRoot: "C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
 
-    steps:
-    - powershell: vcpkg install --triplet "$(vcpkgTriplet)" rapidjson gtest
-      displayName: Install packages with VcPkg
+  #   steps:
+  #   - powershell: vcpkg install --triplet "$(vcpkgTriplet)" rapidjson gtest
+  #     displayName: Install packages with VcPkg
 
-    - task: CMake@1
-      inputs:
-        workingDirectory: 'built\Int\cmake_$(buildPlatform)'
-        cmakeArgs: '..\..\.. -G "Visual Studio 15 2017" -A "$(buildPlatform)" -DCMAKE_TOOLCHAIN_FILE="$(vcpkgRoot)" -DVCPKG_TARGET_TRIPLET="$(vcpkgTriplet)"'
+  #   - task: CMake@1
+  #     inputs:
+  #       workingDirectory: 'built\Int\cmake_$(buildPlatform)'
+  #       cmakeArgs: '..\..\.. -G "Visual Studio 16 2019" -A "$(buildPlatform)" -DCMAKE_TOOLCHAIN_FILE="$(vcpkgRoot)" -DVCPKG_TARGET_TRIPLET="$(vcpkgTriplet)"'
 
-    - task: CMake@1
-      inputs:
-        workingDirectory: 'built\Int\cmake_$(buildPlatform)'
-        cmakeArgs: '--build . --target install --config $(buildConfiguration) -- /m'
+  #   - task: CMake@1
+  #     inputs:
+  #       workingDirectory: 'built\Int\cmake_$(buildPlatform)'
+  #       cmakeArgs: '--build . --target install --config $(buildConfiguration) -- /m'
 
-    # copy googletest related dll files
-    - task: CopyFiles@2
-      inputs:
-        sourceFolder: 'built\Int\cmake_$(buildPlatform)\GLTFSDK.Test\$(buildConfiguration)'
-        contents: 'gtest*.dll'
-        targetFolder: 'built\Out\windows_$(buildPlatform)\$(buildConfiguration)\GLTFSDK.Test'
-        overWrite: true
-      condition: in(variables['buildPlatform'], 'Win32', 'x64')
+  #   # copy googletest related dll files
+  #   - task: CopyFiles@2
+  #     inputs:
+  #       sourceFolder: 'built\Int\cmake_$(buildPlatform)\GLTFSDK.Test\$(buildConfiguration)'
+  #       contents: 'gtest*.dll'
+  #       targetFolder: 'built\Out\windows_$(buildPlatform)\$(buildConfiguration)\GLTFSDK.Test'
+  #       overWrite: true
+  #     condition: in(variables['buildPlatform'], 'Win32', 'x64')
 
-    - script: .\GLTFSDK.Test.exe --gtest_output=xml:GLTFSDK.Test.log
-      workingDirectory: built\Out\windows_$(buildPlatform)\$(buildConfiguration)\GLTFSDK.Test
-      displayName: Running Unit Tests
-      condition: and(succeeded(), in(variables['buildPlatform'], 'Win32', 'x64'))
+  #   - script: .\GLTFSDK.Test.exe --gtest_output=xml:GLTFSDK.Test.log
+  #     workingDirectory: built\Out\windows_$(buildPlatform)\$(buildConfiguration)\GLTFSDK.Test
+  #     displayName: Running Unit Tests
+  #     condition: and(succeeded(), in(variables['buildPlatform'], 'Win32', 'x64'))
 
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: built\Out\windows_$(buildPlatform)\$(buildConfiguration)\GLTFSDK.Test\GLTFSDK.Test.log
-      condition: and(succeeded(), in(variables['buildPlatform'], 'Win32', 'x64'))
-
-  - job: WindowsVcPkg_VS2019
-
-    pool:
-      vmImage: 'windows-2019'
-
-    strategy:
-      matrix:
-        Win32-Release:
-          buildPlatform: Win32
-          buildConfiguration: Release
-          vcpkgTriplet: x86-windows
-        Win32-Debug:
-          buildPlatform: Win32
-          buildConfiguration: Debug
-          vcpkgTriplet: x86-windows
-        x64-Release:
-          buildPlatform: x64
-          buildConfiguration: Release
-          vcpkgTriplet: x64-windows
-        x64-Debug:
-          buildPlatform: x64
-          buildConfiguration: Debug
-          vcpkgTriplet: x64-windows
-        ARM-Release:
-          buildPlatform: ARM
-          buildConfiguration: Release
-          vcpkgTriplet: arm-windows
-        ARM-Debug:
-          buildPlatform: ARM
-          buildConfiguration: Debug
-          vcpkgTriplet: arm-windows
-        ARM64-Release:
-          buildPlatform: ARM64
-          buildConfiguration: Release
-          vcpkgTriplet: arm64-windows
-        ARM64-Debug:
-          buildPlatform: ARM64
-          buildConfiguration: Debug
-          vcpkgTriplet: arm64-windows
-
-    workspace:
-      clean: all
-
-    variables:
-      vcpkgRoot: "C:/vcpkg/scripts/buildsystems/vcpkg.cmake"
-
-    steps:
-    - powershell: vcpkg install --triplet "$(vcpkgTriplet)" rapidjson gtest
-      displayName: Install packages with VcPkg
-
-    - task: CMake@1
-      inputs:
-        workingDirectory: 'built\Int\cmake_$(buildPlatform)'
-        cmakeArgs: '..\..\.. -G "Visual Studio 16 2019" -A "$(buildPlatform)" -DCMAKE_TOOLCHAIN_FILE="$(vcpkgRoot)" -DVCPKG_TARGET_TRIPLET="$(vcpkgTriplet)"'
-
-    - task: CMake@1
-      inputs:
-        workingDirectory: 'built\Int\cmake_$(buildPlatform)'
-        cmakeArgs: '--build . --target install --config $(buildConfiguration) -- /m'
-
-    # copy googletest related dll files
-    - task: CopyFiles@2
-      inputs:
-        sourceFolder: 'built\Int\cmake_$(buildPlatform)\GLTFSDK.Test\$(buildConfiguration)'
-        contents: 'gtest*.dll'
-        targetFolder: 'built\Out\windows_$(buildPlatform)\$(buildConfiguration)\GLTFSDK.Test'
-        overWrite: true
-      condition: in(variables['buildPlatform'], 'Win32', 'x64')
-
-    - script: .\GLTFSDK.Test.exe --gtest_output=xml:GLTFSDK.Test.log
-      workingDirectory: built\Out\windows_$(buildPlatform)\$(buildConfiguration)\GLTFSDK.Test
-      displayName: Running Unit Tests
-      condition: and(succeeded(), in(variables['buildPlatform'], 'Win32', 'x64'))
-
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: built\Out\windows_$(buildPlatform)\$(buildConfiguration)\GLTFSDK.Test\GLTFSDK.Test.log
-      condition: and(succeeded(), in(variables['buildPlatform'], 'Win32', 'x64'))
+  #   - task: PublishTestResults@2
+  #     inputs:
+  #       testResultsFormat: 'JUnit'
+  #       testResultsFiles: built\Out\windows_$(buildPlatform)\$(buildConfiguration)\GLTFSDK.Test\GLTFSDK.Test.log
+  #     condition: and(succeeded(), in(variables['buildPlatform'], 'Win32', 'x64'))
 
   - job: MacOS
 
@@ -318,50 +180,50 @@ jobs:
         testResultsFormat: 'JUnit'
         testResultsFiles: built/Out/$(buildPlatform)/$(buildConfiguration)/GLTFSDK.Test/GLTFSDK.Test.log
 
-  - job: MacOSVcPkg
+  # - job: MacOSVcPkg
 
-    pool:
-      vmImage: 'macOS-10.15'
+  #   pool:
+  #     vmImage: 'macOS-10.15'
     
-    strategy:
-      matrix:
-        macOS-Release:
-          buildPlatform: macOS
-          buildConfiguration: Release
-          vcpkgTriplet: x64-osx
-        macOS-Debug:
-          buildPlatform: macOS
-          buildConfiguration: Debug
-          vcpkgTriplet: x64-osx
+  #   strategy:
+  #     matrix:
+  #       macOS-Release:
+  #         buildPlatform: macOS
+  #         buildConfiguration: Release
+  #         vcpkgTriplet: x64-osx
+  #       macOS-Debug:
+  #         buildPlatform: macOS
+  #         buildConfiguration: Debug
+  #         vcpkgTriplet: x64-osx
 
-    workspace:
-      clean: all
+  #   workspace:
+  #     clean: all
 
-    steps:
-    - task: Bash@3
-      inputs:
-        targetType: 'inline'
-        script: vcpkg install --triplet "$(vcpkgTriplet)" rapidjson gtest
-      displayName: Install packages with VcPkg
+  #   steps:
+  #   - task: Bash@3
+  #     inputs:
+  #       targetType: 'inline'
+  #       script: vcpkg install --triplet "$(vcpkgTriplet)" rapidjson gtest
+  #     displayName: Install packages with VcPkg
 
-    - task: CMake@1
-      inputs:
-        workingDirectory: 'built/Int/cmake_$(buildPlatform)'
-        cmakeArgs: '../../.. -G Xcode -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake'
+  #   - task: CMake@1
+  #     inputs:
+  #       workingDirectory: 'built/Int/cmake_$(buildPlatform)'
+  #       cmakeArgs: '../../.. -G Xcode -DCMAKE_TOOLCHAIN_FILE=/usr/local/share/vcpkg/scripts/buildsystems/vcpkg.cmake'
 
-    - task: CMake@1
-      inputs:
-        workingDirectory: 'built/Int/cmake_$(buildPlatform)'
-        cmakeArgs: '--build . --target install --config $(buildConfiguration)'
+  #   - task: CMake@1
+  #     inputs:
+  #       workingDirectory: 'built/Int/cmake_$(buildPlatform)'
+  #       cmakeArgs: '--build . --target install --config $(buildConfiguration)'
 
-    - script: ./GLTFSDK.Test --gtest_output=xml:GLTFSDK.Test.log
-      workingDirectory: built/Out/$(buildPlatform)/$(buildConfiguration)/GLTFSDK.Test
-      displayName: Running Unit Tests
+  #   - script: ./GLTFSDK.Test --gtest_output=xml:GLTFSDK.Test.log
+  #     workingDirectory: built/Out/$(buildPlatform)/$(buildConfiguration)/GLTFSDK.Test
+  #     displayName: Running Unit Tests
 
-    - task: PublishTestResults@2
-      inputs:
-        testResultsFormat: 'JUnit'
-        testResultsFiles: built/Out/$(buildPlatform)/$(buildConfiguration)/GLTFSDK.Test/GLTFSDK.Test.log
+  #   - task: PublishTestResults@2
+  #     inputs:
+  #       testResultsFormat: 'JUnit'
+  #       testResultsFiles: built/Out/$(buildPlatform)/$(buildConfiguration)/GLTFSDK.Test/GLTFSDK.Test.log
 
   - job: iOS
 

--- a/Build/AzureDevOps/azure-pipelines.yml
+++ b/Build/AzureDevOps/azure-pipelines.yml
@@ -283,7 +283,7 @@ jobs:
   - job: MacOS
 
     pool:
-      vmImage: 'macOS-10.14'
+      vmImage: 'macOS-10.15'
     
     strategy:
       matrix:
@@ -366,7 +366,7 @@ jobs:
   - job: iOS
 
     pool:
-      vmImage: 'macOS-10.14'
+      vmImage: 'macOS-10.15'
     
     strategy:
       matrix:

--- a/Build/CMake/Modules/GLTFPlatform.cmake
+++ b/Build/CMake/Modules/GLTFPlatform.cmake
@@ -85,11 +85,11 @@ function(AddGLTFIOSAppProperties target)
         find_library(SYSTEMCONFIGURATION SystemConfiguration)
 
         # link the frameworks located above
-        target_link_libraries(${target} ${UIKIT})
-        target_link_libraries(${target} ${FOUNDATION})
-        target_link_libraries(${target} ${MOBILECORESERVICES})
-        target_link_libraries(${target} ${CFNETWORK})
-        target_link_libraries(${target} ${SYSTEMCONFIGURATION})
+        target_link_libraries(${target} PRIVATE ${UIKIT})
+        target_link_libraries(${target} PRIVATE ${FOUNDATION})
+        target_link_libraries(${target} PRIVATE ${MOBILECORESERVICES})
+        target_link_libraries(${target} PRIVATE ${CFNETWORK})
+        target_link_libraries(${target} PRIVATE ${SYSTEMCONFIGURATION})
 
         set_target_properties(${target} PROPERTIES
             MACOSX_BUNDLE true

--- a/External/RapidJSON/CMakeRapidJSONDownload.txt.in
+++ b/External/RapidJSON/CMakeRapidJSONDownload.txt.in
@@ -5,7 +5,7 @@ project(RapidJSON-download NONE)
 include(ExternalProject)
 ExternalProject_Add(RapidJSON
   GIT_REPOSITORY    https://github.com/Tencent/rapidjson.git
-  GIT_TAG           ce81bc9edfe773667a7a4454ba81dac72ed4364c
+  GIT_TAG           232389d4f1012dddec4ef84861face2d2ba85709
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/RapidJSON-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/RapidJSON-build"
   CONFIGURE_COMMAND ""

--- a/External/RapidJSON/CMakeRapidJSONDownload.txt.in
+++ b/External/RapidJSON/CMakeRapidJSONDownload.txt.in
@@ -5,7 +5,7 @@ project(RapidJSON-download NONE)
 include(ExternalProject)
 ExternalProject_Add(RapidJSON
   GIT_REPOSITORY    https://github.com/Tencent/rapidjson.git
-  GIT_TAG           3b638e67150783303aebf1fc0789d6c44a026b53
+  GIT_TAG           8261c1ddf43f10de00fd8c9a67811d1486b2c784
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/RapidJSON-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/RapidJSON-build"
   CONFIGURE_COMMAND ""

--- a/External/RapidJSON/CMakeRapidJSONDownload.txt.in
+++ b/External/RapidJSON/CMakeRapidJSONDownload.txt.in
@@ -5,7 +5,7 @@ project(RapidJSON-download NONE)
 include(ExternalProject)
 ExternalProject_Add(RapidJSON
   GIT_REPOSITORY    https://github.com/Tencent/rapidjson.git
-  GIT_TAG           8261c1ddf43f10de00fd8c9a67811d1486b2c784
+  GIT_TAG           ce81bc9edfe773667a7a4454ba81dac72ed4364c
   SOURCE_DIR        "${CMAKE_BINARY_DIR}/RapidJSON-src"
   BINARY_DIR        "${CMAKE_BINARY_DIR}/RapidJSON-build"
   CONFIGURE_COMMAND ""

--- a/GLTFSDK/Source/ExtensionsKHR.cpp
+++ b/GLTFSDK/Source/ExtensionsKHR.cpp
@@ -234,7 +234,7 @@ std::unique_ptr<Extension> KHR::Materials::DeserializePBRSpecGloss(const std::st
     Materials::PBRSpecularGlossiness specGloss;
 
     auto doc = RapidJsonUtils::CreateDocumentFromString(json);
-    const rapidjson::Value sit = doc.GetObject();
+    const auto sit = doc.GetObject();
 
     // Diffuse Factor
     auto diffuseFactIt = sit.FindMember("diffuseFactor");
@@ -314,7 +314,7 @@ std::unique_ptr<Extension> KHR::Materials::DeserializeUnlit(const std::string& j
     Unlit unlit;
 
     auto doc = RapidJsonUtils::CreateDocumentFromString(json);
-    const rapidjson::Value objValue = doc.GetObject();
+    const auto objValue = doc.GetObject();
 
     ParseProperty(objValue, unlit, extensionDeserializer);
 
@@ -375,7 +375,7 @@ std::unique_ptr<Extension> KHR::MeshPrimitives::DeserializeDracoMeshCompression(
     auto extension = std::make_unique<DracoMeshCompression>();
 
     auto doc = RapidJsonUtils::CreateDocumentFromString(json);
-    const rapidjson::Value v = doc.GetObject();
+    const auto v = doc.GetObject();
 
     extension->bufferViewId = GetMemberValueAsString<uint32_t>(v, "bufferView");
 
@@ -481,7 +481,7 @@ std::unique_ptr<Extension> KHR::TextureInfos::DeserializeTextureTransform(const 
     TextureTransform textureTransform;
 
     auto doc = RapidJsonUtils::CreateDocumentFromString(json);
-    const rapidjson::Value sit = doc.GetObject();
+    const auto sit = doc.GetObject();
 
     // Offset
     auto offsetIt = sit.FindMember("offset");

--- a/GLTFSDK/Source/SchemaValidation.cpp
+++ b/GLTFSDK/Source/SchemaValidation.cpp
@@ -18,7 +18,7 @@ namespace
             assert(this->schemaLocator);
         }
 
-        const rapidjson::SchemaDocument* GetRemoteDocument(const std::string& uri)
+        const rapidjson::SchemaDocument* GetRemoteDocumentStr(const std::string& uri)
         {
             auto itDoc = schemaDocuments.find(uri);
 
@@ -44,7 +44,7 @@ namespace
 
         const rapidjson::SchemaDocument* GetRemoteDocument(const char* uri, rapidjson::SizeType length) override
         {
-            return GetRemoteDocument({ uri, length });
+            return GetRemoteDocumentStr(std::string(uri, length));
         }
 
         const std::unique_ptr<const ISchemaLocator> schemaLocator;
@@ -63,7 +63,7 @@ void Microsoft::glTF::ValidateDocumentAgainstSchema(const rapidjson::Document& d
 
     RemoteSchemaDocumentProvider provider(std::move(schemaLocator));
 
-    if (auto* schemaDocument = provider.GetRemoteDocument(schemaUri))
+    if (auto* schemaDocument = provider.GetRemoteDocumentStr(schemaUri))
     {
         rapidjson::SchemaValidator schemaValidator(*schemaDocument);
 


### PR DESCRIPTION
This PR adds support to gltf-SDK to be used with the latest versions of rapidjson. 

# Changes 

With the updated to rapidjson IGenericRemoteSchemaDocumentProvider added a new overload to GetRemoteDocument that conflicts with  RemoteSchemaDocumentProvider::GetRemoteDocument(const std::string&)

The method had to be renamed to GetRemoteDocumentStr to avoid collision. 

Also, some types were replaced by auto in order to avoid ambiguities now that a cast from  rapidjson::GenericObject<false, ValueType> to apidjson::GenericObject<true, ValueType> was added.

Updated rapidjson version.