### PR TITLE
Size calls assert/abort when not of type array

### DIFF
--- a/GLTFSDK/Source/ExtensionsKHR.cpp
+++ b/GLTFSDK/Source/ExtensionsKHR.cpp
@@ -487,6 +487,11 @@ std::unique_ptr<Extension> KHR::TextureInfos::DeserializeTextureTransform(const 
     auto offsetIt = sit.FindMember("offset");
     if (offsetIt != sit.MemberEnd())
     {
+        if (!offsetIt->value.IsArray())
+        {
+            throw GLTFException("Offset member of " + std::string(TEXTURETRANSFORM_NAME) + " must be an array.");
+        }
+
         if (offsetIt->value.Size() != 2)
         {
             throw GLTFException("Offset member of " + std::string(TEXTURETRANSFORM_NAME) + " must have two values.");
@@ -508,6 +513,11 @@ std::unique_ptr<Extension> KHR::TextureInfos::DeserializeTextureTransform(const 
     auto scaleIt = sit.FindMember("scale");
     if (scaleIt != sit.MemberEnd())
     {
+        if (!scaleIt->value.IsArray())
+        {
+            throw GLTFException("Scale member of " + std::string(TEXTURETRANSFORM_NAME) + " must be an array.");
+        }
+
         if (scaleIt->value.Size() != 2)
         {
             throw GLTFException("Scale member of " + std::string(TEXTURETRANSFORM_NAME) + " must have two values.");


### PR DESCRIPTION
Add a check to `IsArray()` before calling `Size()` because if member is not an array, rapidjson asserts which results with a call to abort.