### PR TITLE
Cherry picks 197e5c59 from master to branch 1.9.5

### DIFF
--- a/GLTFSDK/Source/Deserialize.cpp
+++ b/GLTFSDK/Source/Deserialize.cpp
@@ -203,6 +203,7 @@ namespace
     Scene ParseScene(const rapidjson::Value& v, const ExtensionDeserializer& extensionDeserializer)
     {
         Scene scene;
+        scene.name = GetMemberValueOrDefault<std::string>(v, "name");
 
         rapidjson::Value::ConstMemberIterator it = v.FindMember("nodes");
         if (it != v.MemberEnd())


### PR DESCRIPTION
The following commit from 4/4/23 was made on the master branch but has not made it into the 1.9.5 release branch.

Add missing scene name (#117)
(cherry picked from commit 197e5c59d09e4e87efe66276f4ea240f28bb9cd7)