### PR TITLE
Add `GLTFSDK_API` definition to make calling convention modifier explicit

### DIFF
--- a/External/googletest/CMakeLists.txt
+++ b/External/googletest/CMakeLists.txt
@@ -35,3 +35,12 @@ add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
 if (CMAKE_VERSION VERSION_LESS 2.8.11)
   include_directories("${gtest_SOURCE_DIR}/include")
 endif()
+
+if(MSVC AND CMAKE_VS_PLATFORM_NAME STREQUAL "Win32")
+  # Use __stdcall calling convention for Win32/x86 builds.
+  target_compile_options(gtest PRIVATE "/Gz")
+  target_compile_options(gtest_main PRIVATE "/Gz")
+
+  # Suppress warning C4007: 'main': must be '__cdecl' that gets treated as an error.
+  target_compile_options(gtest_main PRIVATE "/wd4007")
+endif()

--- a/External/googletest/CMakeLists.txt
+++ b/External/googletest/CMakeLists.txt
@@ -35,12 +35,3 @@ add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
 if (CMAKE_VERSION VERSION_LESS 2.8.11)
   include_directories("${gtest_SOURCE_DIR}/include")
 endif()
-
-if(MSVC AND CMAKE_VS_PLATFORM_NAME STREQUAL "Win32")
-  # Use __stdcall calling convention for Win32/x86 builds.
-  target_compile_options(gtest PRIVATE "/Gz")
-  target_compile_options(gtest_main PRIVATE "/Gz")
-
-  # Suppress warning C4007: 'main': must be '__cdecl' that gets treated as an error.
-  target_compile_options(gtest_main PRIVATE "/wd4007")
-endif()

--- a/GLTFSDK.Test/CMakeLists.txt
+++ b/GLTFSDK.Test/CMakeLists.txt
@@ -16,11 +16,6 @@ if (MSVC)
     # Set warning level to 4 (/W4)
     target_compile_options(GLTFSDK.Test PRIVATE "/Zi;/W4;/EHsc")
 
-    # Use __stdcall calling convention for Win32/x86 builds.
-    if(CMAKE_VS_PLATFORM_NAME STREQUAL "Win32")
-        target_compile_options(GLTFSDK.Test PRIVATE "/Gz")
-    endif()
-
     # Make sure that all PDB files on Windows are installed to the output folder.  By default, only the debug build does this.
     set_target_properties(GLTFSDK.Test PROPERTIES COMPILE_PDB_NAME "GLTFSDK.Test" COMPILE_PDB_OUTPUT_DIRECTORY "${RUNTIME_OUTPUT_DIRECTORY}")
 endif()

--- a/GLTFSDK.Test/CMakeLists.txt
+++ b/GLTFSDK.Test/CMakeLists.txt
@@ -16,6 +16,11 @@ if (MSVC)
     # Set warning level to 4 (/W4)
     target_compile_options(GLTFSDK.Test PRIVATE "/Zi;/W4;/EHsc")
 
+    # Use __stdcall calling convention for Win32/x86 builds.
+    if(CMAKE_VS_PLATFORM_NAME STREQUAL "Win32")
+        target_compile_options(GLTFSDK.Test PRIVATE "/Gz")
+    endif()
+
     # Make sure that all PDB files on Windows are installed to the output folder.  By default, only the debug build does this.
     set_target_properties(GLTFSDK.Test PROPERTIES COMPILE_PDB_NAME "GLTFSDK.Test" COMPILE_PDB_OUTPUT_DIRECTORY "${RUNTIME_OUTPUT_DIRECTORY}")
 endif()

--- a/GLTFSDK/Inc/GLTFSDK/AnimationUtils.h
+++ b/GLTFSDK/Inc/GLTFSDK/AnimationUtils.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <GLTFSDK/Definitions.h>
+
 #include <vector>
 
 namespace Microsoft
@@ -17,23 +19,23 @@ namespace Microsoft
 
         namespace AnimationUtils
         {
-            std::vector<float> GetKeyframeTimes(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GetKeyframeTimes(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler);
+            std::vector<float> GLTFSDK_CDECL GetKeyframeTimes(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_CDECL GetKeyframeTimes(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler);
 
-            std::vector<float> GetInverseBindMatrices(const Document& doc, const GLTFResourceReader& reader, const Accessor& skin);
-            std::vector<float> GetInverseBindMatrices(const Document& doc, const GLTFResourceReader& reader, const Skin& skin);
+            std::vector<float> GLTFSDK_CDECL GetInverseBindMatrices(const Document& doc, const GLTFResourceReader& reader, const Accessor& skin);
+            std::vector<float> GLTFSDK_CDECL GetInverseBindMatrices(const Document& doc, const GLTFResourceReader& reader, const Skin& skin);
 
-            std::vector<float> GetTranslations(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GetTranslations(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
+            std::vector<float> GLTFSDK_CDECL GetTranslations(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_CDECL GetTranslations(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
 
-            std::vector<float> GetRotations(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GetRotations(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
+            std::vector<float> GLTFSDK_CDECL GetRotations(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_CDECL GetRotations(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
 
-            std::vector<float> GetScales(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GetScales(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
+            std::vector<float> GLTFSDK_CDECL GetScales(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_CDECL GetScales(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
 
-            std::vector<float> GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
+            std::vector<float> GLTFSDK_CDECL GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_CDECL GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
         };
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/AnimationUtils.h
+++ b/GLTFSDK/Inc/GLTFSDK/AnimationUtils.h
@@ -19,23 +19,23 @@ namespace Microsoft
 
         namespace AnimationUtils
         {
-            std::vector<float> GLTFSDK_CDECL GetKeyframeTimes(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GLTFSDK_CDECL GetKeyframeTimes(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler);
+            std::vector<float> GLTFSDK_API GetKeyframeTimes(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_API GetKeyframeTimes(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler);
 
-            std::vector<float> GLTFSDK_CDECL GetInverseBindMatrices(const Document& doc, const GLTFResourceReader& reader, const Accessor& skin);
-            std::vector<float> GLTFSDK_CDECL GetInverseBindMatrices(const Document& doc, const GLTFResourceReader& reader, const Skin& skin);
+            std::vector<float> GLTFSDK_API GetInverseBindMatrices(const Document& doc, const GLTFResourceReader& reader, const Accessor& skin);
+            std::vector<float> GLTFSDK_API GetInverseBindMatrices(const Document& doc, const GLTFResourceReader& reader, const Skin& skin);
 
-            std::vector<float> GLTFSDK_CDECL GetTranslations(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GLTFSDK_CDECL GetTranslations(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
+            std::vector<float> GLTFSDK_API GetTranslations(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_API GetTranslations(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
 
-            std::vector<float> GLTFSDK_CDECL GetRotations(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GLTFSDK_CDECL GetRotations(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
+            std::vector<float> GLTFSDK_API GetRotations(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_API GetRotations(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
 
-            std::vector<float> GLTFSDK_CDECL GetScales(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GLTFSDK_CDECL GetScales(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
+            std::vector<float> GLTFSDK_API GetScales(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_API GetScales(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
 
-            std::vector<float> GLTFSDK_CDECL GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GLTFSDK_CDECL GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
+            std::vector<float> GLTFSDK_API GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_API GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& accessor);
         };
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
+++ b/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
@@ -36,7 +36,7 @@ namespace Microsoft
 
         class BufferBuilder final
         {
-            typedef std::function<std::string GLTFSDK_CDECL (const BufferBuilder&)> FnGenId;
+            typedef std::function<std::string GLTFSDK_API (const BufferBuilder&)> FnGenId;
 
         public:
             BufferBuilder(std::unique_ptr<ResourceWriter>&& resourceWriter);

--- a/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
+++ b/GLTFSDK/Inc/GLTFSDK/BufferBuilder.h
@@ -36,7 +36,7 @@ namespace Microsoft
 
         class BufferBuilder final
         {
-            typedef std::function<std::string(const BufferBuilder&)> FnGenId;
+            typedef std::function<std::string GLTFSDK_CDECL (const BufferBuilder&)> FnGenId;
 
         public:
             BufferBuilder(std::unique_ptr<ResourceWriter>&& resourceWriter);

--- a/GLTFSDK/Inc/GLTFSDK/Color.h
+++ b/GLTFSDK/Inc/GLTFSDK/Color.h
@@ -125,7 +125,7 @@ namespace Microsoft
             Color3(float r, float g, float b);
             Color3(uint8_t r, uint8_t g, uint8_t b);
 
-            static Color3 GLTFSDK_CDECL FromScalar(float value);
+            static Color3 GLTFSDK_API FromScalar(float value);
 
             Color3& operator*=(const Color3& rhs);
             Color3& operator*=(float rhs);
@@ -147,14 +147,14 @@ namespace Microsoft
             uint32_t AsUint32RGBA() const;
             uint32_t AsUint32BGRA() const;
 
-            static Color3 GLTFSDK_CDECL FromUint32RGBA(uint32_t color);
-            static Color3 GLTFSDK_CDECL FromUint32BGRA(uint32_t color);
+            static Color3 GLTFSDK_API FromUint32RGBA(uint32_t color);
+            static Color3 GLTFSDK_API FromUint32BGRA(uint32_t color);
 
-            static Color3 GLTFSDK_CDECL Clamp(const Color3& color, float lo, float hi);
+            static Color3 GLTFSDK_API Clamp(const Color3& color, float lo, float hi);
         };
 
-        bool GLTFSDK_CDECL operator==(const Color3& lhs, const Color3& rhs);
-        bool GLTFSDK_CDECL operator!=(const Color3& lhs, const Color3& rhs);
+        bool GLTFSDK_API operator==(const Color3& lhs, const Color3& rhs);
+        bool GLTFSDK_API operator!=(const Color3& lhs, const Color3& rhs);
 
         struct Color4 : private ColorBase<Color4>
         {
@@ -168,7 +168,7 @@ namespace Microsoft
             Color4(float r, float g, float b, float a);
             Color4(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
-            static Color4 GLTFSDK_CDECL FromScalar(float value);
+            static Color4 GLTFSDK_API FromScalar(float value);
 
             Color4& operator*=(const Color4& rhs);
             Color4& operator*=(float);
@@ -187,13 +187,13 @@ namespace Microsoft
             uint32_t AsUint32RGBA() const;
             uint32_t AsUint32BGRA() const;
 
-            static Color4 GLTFSDK_CDECL FromUint32RGBA(uint32_t color);
-            static Color4 GLTFSDK_CDECL FromUint32BGRA(uint32_t color);
+            static Color4 GLTFSDK_API FromUint32RGBA(uint32_t color);
+            static Color4 GLTFSDK_API FromUint32BGRA(uint32_t color);
 
-            static Color4 GLTFSDK_CDECL Clamp(const Color4& color, float lo, float hi);
+            static Color4 GLTFSDK_API Clamp(const Color4& color, float lo, float hi);
         };
 
-        bool GLTFSDK_CDECL operator==(const Color4& lhs, const Color4& rhs);
-        bool GLTFSDK_CDECL operator!=(const Color4& lhs, const Color4& rhs);
+        bool GLTFSDK_API operator==(const Color4& lhs, const Color4& rhs);
+        bool GLTFSDK_API operator!=(const Color4& lhs, const Color4& rhs);
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/Color.h
+++ b/GLTFSDK/Inc/GLTFSDK/Color.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <GLTFSDK/Definitions.h>
+
 #include <cstdint>
 
 namespace Microsoft
@@ -123,7 +125,7 @@ namespace Microsoft
             Color3(float r, float g, float b);
             Color3(uint8_t r, uint8_t g, uint8_t b);
 
-            static Color3 FromScalar(float value);
+            static Color3 GLTFSDK_CDECL FromScalar(float value);
 
             Color3& operator*=(const Color3& rhs);
             Color3& operator*=(float rhs);
@@ -145,14 +147,14 @@ namespace Microsoft
             uint32_t AsUint32RGBA() const;
             uint32_t AsUint32BGRA() const;
 
-            static Color3 FromUint32RGBA(uint32_t color);
-            static Color3 FromUint32BGRA(uint32_t color);
+            static Color3 GLTFSDK_CDECL FromUint32RGBA(uint32_t color);
+            static Color3 GLTFSDK_CDECL FromUint32BGRA(uint32_t color);
 
-            static Color3 Clamp(const Color3& color, float lo, float hi);
+            static Color3 GLTFSDK_CDECL Clamp(const Color3& color, float lo, float hi);
         };
 
-        bool operator==(const Color3& lhs, const Color3& rhs);
-        bool operator!=(const Color3& lhs, const Color3& rhs);
+        bool GLTFSDK_CDECL operator==(const Color3& lhs, const Color3& rhs);
+        bool GLTFSDK_CDECL operator!=(const Color3& lhs, const Color3& rhs);
 
         struct Color4 : private ColorBase<Color4>
         {
@@ -166,7 +168,7 @@ namespace Microsoft
             Color4(float r, float g, float b, float a);
             Color4(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
-            static Color4 FromScalar(float value);
+            static Color4 GLTFSDK_CDECL FromScalar(float value);
 
             Color4& operator*=(const Color4& rhs);
             Color4& operator*=(float);
@@ -185,13 +187,13 @@ namespace Microsoft
             uint32_t AsUint32RGBA() const;
             uint32_t AsUint32BGRA() const;
 
-            static Color4 FromUint32RGBA(uint32_t color);
-            static Color4 FromUint32BGRA(uint32_t color);
+            static Color4 GLTFSDK_CDECL FromUint32RGBA(uint32_t color);
+            static Color4 GLTFSDK_CDECL FromUint32BGRA(uint32_t color);
 
-            static Color4 Clamp(const Color4& color, float lo, float hi);
+            static Color4 GLTFSDK_CDECL Clamp(const Color4& color, float lo, float hi);
         };
 
-        bool operator==(const Color4& lhs, const Color4& rhs);
-        bool operator!=(const Color4& lhs, const Color4& rhs);
+        bool GLTFSDK_CDECL operator==(const Color4& lhs, const Color4& rhs);
+        bool GLTFSDK_CDECL operator!=(const Color4& lhs, const Color4& rhs);
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/Definitions.h
+++ b/GLTFSDK/Inc/GLTFSDK/Definitions.h
@@ -3,8 +3,10 @@
 
 #pragma once
 
+#ifndef GLTFSDK_API
 #ifdef _WIN32
-#define GLTFSDK_CDECL __cdecl
+#define GLTFSDK_API __cdecl
 #else
-#define GLTFSDK_CDECL
+#define GLTFSDK_API
+#endif
 #endif

--- a/GLTFSDK/Inc/GLTFSDK/Definitions.h
+++ b/GLTFSDK/Inc/GLTFSDK/Definitions.h
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#ifdef _WIN32
+#define GLTFSDK_CDECL __cdecl
+#else
+#define GLTFSDK_CDECL
+#endif

--- a/GLTFSDK/Inc/GLTFSDK/Deserialize.h
+++ b/GLTFSDK/Inc/GLTFSDK/Deserialize.h
@@ -6,7 +6,7 @@
 #include <GLTFSDK/Document.h>
 #include <GLTFSDK/Schema.h>
 
-namespace Microsoft 
+namespace Microsoft
 {
     namespace glTF
     {
@@ -24,10 +24,10 @@ namespace Microsoft
 
         class ExtensionDeserializer;
 
-        Document Deserialize(const std::string& json, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
-        Document Deserialize(const std::string& json, const ExtensionDeserializer& extensions, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
+        Document GLTFSDK_CDECL Deserialize(const std::string& json, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
+        Document GLTFSDK_CDECL Deserialize(const std::string& json, const ExtensionDeserializer& extensions, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
 
-        Document Deserialize(std::istream& jsonStream, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
-        Document Deserialize(std::istream& jsonStream, const ExtensionDeserializer& extensions, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
+        Document GLTFSDK_CDECL Deserialize(std::istream& jsonStream, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
+        Document GLTFSDK_CDECL Deserialize(std::istream& jsonStream, const ExtensionDeserializer& extensions, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/Deserialize.h
+++ b/GLTFSDK/Inc/GLTFSDK/Deserialize.h
@@ -24,10 +24,10 @@ namespace Microsoft
 
         class ExtensionDeserializer;
 
-        Document GLTFSDK_CDECL Deserialize(const std::string& json, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
-        Document GLTFSDK_CDECL Deserialize(const std::string& json, const ExtensionDeserializer& extensions, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
+        Document GLTFSDK_API Deserialize(const std::string& json, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
+        Document GLTFSDK_API Deserialize(const std::string& json, const ExtensionDeserializer& extensions, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
 
-        Document GLTFSDK_CDECL Deserialize(std::istream& jsonStream, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
-        Document GLTFSDK_CDECL Deserialize(std::istream& jsonStream, const ExtensionDeserializer& extensions, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
+        Document GLTFSDK_API Deserialize(std::istream& jsonStream, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
+        Document GLTFSDK_API Deserialize(std::istream& jsonStream, const ExtensionDeserializer& extensions, DeserializeFlags flags = DeserializeFlags::None, SchemaFlags schemaFlags = SchemaFlags::None);
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/ExtensionsKHR.h
+++ b/GLTFSDK/Inc/GLTFSDK/ExtensionsKHR.h
@@ -15,8 +15,8 @@ namespace Microsoft
     {
         namespace KHR
         {
-            ExtensionSerializer   GLTFSDK_CDECL GetKHRExtensionSerializer();
-            ExtensionDeserializer GLTFSDK_CDECL GetKHRExtensionDeserializer();
+            ExtensionSerializer   GLTFSDK_API GetKHRExtensionSerializer();
+            ExtensionDeserializer GLTFSDK_API GetKHRExtensionDeserializer();
 
             namespace Materials
             {

--- a/GLTFSDK/Inc/GLTFSDK/ExtensionsKHR.h
+++ b/GLTFSDK/Inc/GLTFSDK/ExtensionsKHR.h
@@ -37,8 +37,8 @@ namespace Microsoft
                     bool IsEqual(const Extension& rhs) const override;
                 };
 
-                std::string SerializePBRSpecGloss(const PBRSpecularGlossiness& specGloss, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
-                std::unique_ptr<Extension> DeserializePBRSpecGloss(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
+                std::string GLTFSDK_API SerializePBRSpecGloss(const PBRSpecularGlossiness& specGloss, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
+                std::unique_ptr<Extension> GLTFSDK_API DeserializePBRSpecGloss(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
 
                 constexpr const char* UNLIT_NAME = "KHR_materials_unlit";
 
@@ -49,8 +49,8 @@ namespace Microsoft
                     bool IsEqual(const Extension& rhs) const override;
                 };
 
-                std::string SerializeUnlit(const Unlit& unlit, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
-                std::unique_ptr<Extension> DeserializeUnlit(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
+                std::string GLTFSDK_API SerializeUnlit(const Unlit& unlit, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
+                std::unique_ptr<Extension> GLTFSDK_API DeserializeUnlit(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
 
                 constexpr const char* CLEARCOAT_NAME = "KHR_materials_clearcoat";
 
@@ -69,8 +69,8 @@ namespace Microsoft
                     bool IsEqual(const Extension& rhs) const override;
                 };
 
-                std::string SerializeClearcoat(const Clearcoat& clearcoat, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
-                std::unique_ptr<Extension> DeserializeClearcoat(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
+                std::string GLTFSDK_API SerializeClearcoat(const Clearcoat& clearcoat, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
+                std::unique_ptr<Extension> GLTFSDK_API DeserializeClearcoat(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
 
                 constexpr const char* VOLUME_NAME = "KHR_materials_volume";
 
@@ -88,8 +88,8 @@ namespace Microsoft
                     bool IsEqual(const Extension& rhs) const override;
                 };
 
-                std::string SerializeVolume(const Volume& volume, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
-                std::unique_ptr<Extension> DeserializeVolume(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
+                std::string GLTFSDK_API SerializeVolume(const Volume& volume, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
+                std::unique_ptr<Extension> GLTFSDK_API DeserializeVolume(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
 
                 constexpr const char* IRIDESCENCE_NAME = "KHR_materials_iridescence";
 
@@ -109,8 +109,8 @@ namespace Microsoft
                     bool IsEqual(const Extension& rhs) const override;
                 };
 
-                std::string SerializeIridescence(const Iridescence& iridescence, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
-                std::unique_ptr<Extension> DeserializeIridescence(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
+                std::string GLTFSDK_API SerializeIridescence(const Iridescence& iridescence, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
+                std::unique_ptr<Extension> GLTFSDK_API DeserializeIridescence(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
 
                 constexpr const char* TRANSMISSION_NAME = "KHR_materials_transmission";
 
@@ -126,8 +126,8 @@ namespace Microsoft
                     bool IsEqual(const Extension& rhs) const override;
                 };
 
-                std::string SerializeTransmission(const Transmission& transmission, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
-                std::unique_ptr<Extension> DeserializeTransmission(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
+                std::string GLTFSDK_API SerializeTransmission(const Transmission& transmission, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
+                std::unique_ptr<Extension> GLTFSDK_API DeserializeTransmission(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
 
                 constexpr const char* SHEEN_NAME = "KHR_materials_sheen";
 
@@ -145,8 +145,8 @@ namespace Microsoft
                     bool IsEqual(const Extension& rhs) const override;
                 };
 
-                std::string SerializeSheen(const Sheen& sheen, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
-                std::unique_ptr<Extension> DeserializeSheen(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
+                std::string GLTFSDK_API SerializeSheen(const Sheen& sheen, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
+                std::unique_ptr<Extension> GLTFSDK_API DeserializeSheen(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
 
                 constexpr const char* SPECULAR_NAME = "KHR_materials_specular";
 
@@ -164,8 +164,8 @@ namespace Microsoft
                     bool IsEqual(const Extension& rhs) const override;
                 };
 
-                std::string SerializeSpecular(const Specular& specular, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
-                std::unique_ptr<Extension> DeserializeSpecular(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
+                std::string GLTFSDK_API SerializeSpecular(const Specular& specular, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
+                std::unique_ptr<Extension> GLTFSDK_API DeserializeSpecular(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
             }
 
             namespace MeshPrimitives
@@ -183,8 +183,8 @@ namespace Microsoft
                     bool IsEqual(const Extension& rhs) const override;
                 };
 
-                std::string SerializeDracoMeshCompression(const DracoMeshCompression& dracoMeshCompression, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
-                std::unique_ptr<Extension> DeserializeDracoMeshCompression(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
+                std::string GLTFSDK_API SerializeDracoMeshCompression(const DracoMeshCompression& dracoMeshCompression, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
+                std::unique_ptr<Extension> GLTFSDK_API DeserializeDracoMeshCompression(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
 
                 // KHR_materials_variants: not implemented yet
                 constexpr const char* MATERIALSVARIANTS_NAME = "KHR_materials_variants";
@@ -205,8 +205,8 @@ namespace Microsoft
                     bool IsEqual(const Extension& rhs) const override;
                 };
 
-                std::string SerializeMeshGPUInstancing(const MeshGPUInstancing& meshGPUInstancing, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
-                std::unique_ptr<Extension> DeserializeMeshGPUInstancing(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
+                std::string GLTFSDK_API SerializeMeshGPUInstancing(const MeshGPUInstancing& meshGPUInstancing, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
+                std::unique_ptr<Extension> GLTFSDK_API DeserializeMeshGPUInstancing(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
             }
 
             namespace TextureInfos
@@ -228,8 +228,8 @@ namespace Microsoft
                     bool IsEqual(const Extension& rhs) const override;
                 };
 
-                std::string SerializeTextureTransform(const TextureTransform& textureTransform, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
-                std::unique_ptr<Extension> DeserializeTextureTransform(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
+                std::string GLTFSDK_API SerializeTextureTransform(const TextureTransform& textureTransform, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer);
+                std::unique_ptr<Extension> GLTFSDK_API DeserializeTextureTransform(const std::string& json, const ExtensionDeserializer& extensionDeserializer);
             }
         }
     }

--- a/GLTFSDK/Inc/GLTFSDK/ExtensionsKHR.h
+++ b/GLTFSDK/Inc/GLTFSDK/ExtensionsKHR.h
@@ -15,8 +15,8 @@ namespace Microsoft
     {
         namespace KHR
         {
-            ExtensionSerializer   GetKHRExtensionSerializer();
-            ExtensionDeserializer GetKHRExtensionDeserializer();
+            ExtensionSerializer   GLTFSDK_CDECL GetKHRExtensionSerializer();
+            ExtensionDeserializer GLTFSDK_CDECL GetKHRExtensionDeserializer();
 
             namespace Materials
             {

--- a/GLTFSDK/Inc/GLTFSDK/GLTF.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLTF.h
@@ -5,6 +5,7 @@
 
 #include <GLTFSDK/Color.h>
 #include <GLTFSDK/Constants.h>
+#include <GLTFSDK/Definitions.h>
 #include <GLTFSDK/Exceptions.h>
 #include <GLTFSDK/Extension.h>
 #include <GLTFSDK/IndexedContainer.h>
@@ -876,7 +877,7 @@ namespace Microsoft
 
             virtual ProjectionType GetProjectionType() const = 0;
             virtual std::unique_ptr<Projection> Clone() const = 0;
-            
+
             virtual bool IsValid() const = 0;
 
             bool operator==(const Projection& rhs) const
@@ -1228,7 +1229,7 @@ namespace Microsoft
             }
 
             static WrapMode GetSamplerWrapMode(size_t readValue)
-            { 
+            {
                 switch (readValue)
                 {
                     case Wrap_CLAMP_TO_EDGE:
@@ -1294,7 +1295,7 @@ namespace Microsoft
                 return !operator==(rhs);
             }
         };
-        
+
         struct AnimationSampler : glTFProperty
         {
             std::string id;

--- a/GLTFSDK/Inc/GLTFSDK/MeshPrimitiveUtils.h
+++ b/GLTFSDK/Inc/GLTFSDK/MeshPrimitiveUtils.h
@@ -16,58 +16,58 @@ namespace Microsoft
 
         namespace MeshPrimitiveUtils
         {
-            std::vector<uint16_t> GetIndices16(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<uint16_t> GetIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint16_t> GLTFSDK_CDECL GetIndices16(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<uint16_t> GLTFSDK_CDECL GetIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint32_t> GetIndices32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<uint32_t> GetIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint32_t> GLTFSDK_CDECL GetIndices32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<uint32_t> GLTFSDK_CDECL GetIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint16_t> GetTriangulatedIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
-            std::vector<uint32_t> GetTriangulatedIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint16_t> GLTFSDK_CDECL GetTriangulatedIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint32_t> GLTFSDK_CDECL GetTriangulatedIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint16_t> GetSegmentedIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
-            std::vector<uint32_t> GetSegmentedIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint16_t> GLTFSDK_CDECL GetSegmentedIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint32_t> GLTFSDK_CDECL GetSegmentedIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<float> GetPositions(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GetPositions(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
-            std::vector<float> GetPositions(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget);
+            std::vector<float> GLTFSDK_CDECL GetPositions(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_CDECL GetPositions(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<float> GLTFSDK_CDECL GetPositions(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget);
 
-            std::vector<float> GetNormals(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GetNormals(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
-            std::vector<float> GetNormals(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget);
+            std::vector<float> GLTFSDK_CDECL GetNormals(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_CDECL GetNormals(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<float> GLTFSDK_CDECL GetNormals(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget);
 
-            std::vector<float> GetTangents(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GetTangents(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
-            std::vector<float> GetTangents(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget);
-            std::vector<float> GetMorphTangents(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_CDECL GetTangents(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_CDECL GetTangents(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<float> GLTFSDK_CDECL GetTangents(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget);
+            std::vector<float> GLTFSDK_CDECL GetMorphTangents(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
 
-            std::vector<float> GetTexCoords(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GetTexCoords_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
-            std::vector<float> GetTexCoords_1(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<float> GLTFSDK_CDECL GetTexCoords(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_CDECL GetTexCoords_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<float> GLTFSDK_CDECL GetTexCoords_1(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint32_t> GetColors(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<uint32_t> GetColors_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint32_t> GLTFSDK_CDECL GetColors(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<uint32_t> GLTFSDK_CDECL GetColors_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint32_t> GetJointIndices32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<uint32_t> GetJointIndices32_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint32_t> GLTFSDK_CDECL GetJointIndices32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<uint32_t> GLTFSDK_CDECL GetJointIndices32_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint64_t> GetJointIndices64(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<uint64_t> GetJointIndices64_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint64_t> GLTFSDK_CDECL GetJointIndices64(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<uint64_t> GLTFSDK_CDECL GetJointIndices64_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint32_t> GetJointWeights32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<uint32_t> GetJointWeights32_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint32_t> GLTFSDK_CDECL GetJointWeights32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<uint32_t> GLTFSDK_CDECL GetJointWeights32_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint16_t> ReverseTriangulateIndices16(const uint16_t* indices, size_t indexCount, MeshMode mode);
-            std::vector<uint32_t> ReverseTriangulateIndices32(const uint32_t* indices, size_t indexCount, MeshMode mode);
+            std::vector<uint16_t> GLTFSDK_CDECL ReverseTriangulateIndices16(const uint16_t* indices, size_t indexCount, MeshMode mode);
+            std::vector<uint32_t> GLTFSDK_CDECL ReverseTriangulateIndices32(const uint32_t* indices, size_t indexCount, MeshMode mode);
 
-            std::vector<uint16_t> ReverseTriangulateIndices16(const std::vector<uint16_t>& indices, MeshMode mode);
-            std::vector<uint32_t> ReverseTriangulateIndices32(const std::vector<uint32_t>& indices, MeshMode mode);
+            std::vector<uint16_t> GLTFSDK_CDECL ReverseTriangulateIndices16(const std::vector<uint16_t>& indices, MeshMode mode);
+            std::vector<uint32_t> GLTFSDK_CDECL ReverseTriangulateIndices32(const std::vector<uint32_t>& indices, MeshMode mode);
 
-            std::vector<uint16_t> ReverseSegmentIndices16(const uint16_t* indices, size_t indexCount, MeshMode mode);
-            std::vector<uint32_t> ReverseSegmentIndices32(const uint32_t* indices, size_t indexCount, MeshMode mode);
+            std::vector<uint16_t> GLTFSDK_CDECL ReverseSegmentIndices16(const uint16_t* indices, size_t indexCount, MeshMode mode);
+            std::vector<uint32_t> GLTFSDK_CDECL ReverseSegmentIndices32(const uint32_t* indices, size_t indexCount, MeshMode mode);
 
-            std::vector<uint16_t> ReverseSegmentIndices16(const std::vector<uint16_t>& indices, MeshMode mode);
-            std::vector<uint32_t> ReverseSegmentIndices32(const std::vector<uint32_t>& indices, MeshMode mode);
+            std::vector<uint16_t> GLTFSDK_CDECL ReverseSegmentIndices16(const std::vector<uint16_t>& indices, MeshMode mode);
+            std::vector<uint32_t> GLTFSDK_CDECL ReverseSegmentIndices32(const std::vector<uint32_t>& indices, MeshMode mode);
         };
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/MeshPrimitiveUtils.h
+++ b/GLTFSDK/Inc/GLTFSDK/MeshPrimitiveUtils.h
@@ -16,58 +16,58 @@ namespace Microsoft
 
         namespace MeshPrimitiveUtils
         {
-            std::vector<uint16_t> GLTFSDK_CDECL GetIndices16(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<uint16_t> GLTFSDK_CDECL GetIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint16_t> GLTFSDK_API GetIndices16(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<uint16_t> GLTFSDK_API GetIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint32_t> GLTFSDK_CDECL GetIndices32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<uint32_t> GLTFSDK_CDECL GetIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint32_t> GLTFSDK_API GetIndices32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<uint32_t> GLTFSDK_API GetIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint16_t> GLTFSDK_CDECL GetTriangulatedIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
-            std::vector<uint32_t> GLTFSDK_CDECL GetTriangulatedIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint16_t> GLTFSDK_API GetTriangulatedIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint32_t> GLTFSDK_API GetTriangulatedIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint16_t> GLTFSDK_CDECL GetSegmentedIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
-            std::vector<uint32_t> GLTFSDK_CDECL GetSegmentedIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint16_t> GLTFSDK_API GetSegmentedIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint32_t> GLTFSDK_API GetSegmentedIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<float> GLTFSDK_CDECL GetPositions(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GLTFSDK_CDECL GetPositions(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
-            std::vector<float> GLTFSDK_CDECL GetPositions(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget);
+            std::vector<float> GLTFSDK_API GetPositions(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_API GetPositions(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<float> GLTFSDK_API GetPositions(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget);
 
-            std::vector<float> GLTFSDK_CDECL GetNormals(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GLTFSDK_CDECL GetNormals(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
-            std::vector<float> GLTFSDK_CDECL GetNormals(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget);
+            std::vector<float> GLTFSDK_API GetNormals(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_API GetNormals(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<float> GLTFSDK_API GetNormals(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget);
 
-            std::vector<float> GLTFSDK_CDECL GetTangents(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GLTFSDK_CDECL GetTangents(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
-            std::vector<float> GLTFSDK_CDECL GetTangents(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget);
-            std::vector<float> GLTFSDK_CDECL GetMorphTangents(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_API GetTangents(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_API GetTangents(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<float> GLTFSDK_API GetTangents(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget);
+            std::vector<float> GLTFSDK_API GetMorphTangents(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
 
-            std::vector<float> GLTFSDK_CDECL GetTexCoords(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<float> GLTFSDK_CDECL GetTexCoords_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
-            std::vector<float> GLTFSDK_CDECL GetTexCoords_1(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<float> GLTFSDK_API GetTexCoords(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<float> GLTFSDK_API GetTexCoords_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<float> GLTFSDK_API GetTexCoords_1(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint32_t> GLTFSDK_CDECL GetColors(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<uint32_t> GLTFSDK_CDECL GetColors_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint32_t> GLTFSDK_API GetColors(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<uint32_t> GLTFSDK_API GetColors_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint32_t> GLTFSDK_CDECL GetJointIndices32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<uint32_t> GLTFSDK_CDECL GetJointIndices32_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint32_t> GLTFSDK_API GetJointIndices32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<uint32_t> GLTFSDK_API GetJointIndices32_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint64_t> GLTFSDK_CDECL GetJointIndices64(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<uint64_t> GLTFSDK_CDECL GetJointIndices64_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint64_t> GLTFSDK_API GetJointIndices64(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<uint64_t> GLTFSDK_API GetJointIndices64_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint32_t> GLTFSDK_CDECL GetJointWeights32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
-            std::vector<uint32_t> GLTFSDK_CDECL GetJointWeights32_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
+            std::vector<uint32_t> GLTFSDK_API GetJointWeights32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor);
+            std::vector<uint32_t> GLTFSDK_API GetJointWeights32_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive);
 
-            std::vector<uint16_t> GLTFSDK_CDECL ReverseTriangulateIndices16(const uint16_t* indices, size_t indexCount, MeshMode mode);
-            std::vector<uint32_t> GLTFSDK_CDECL ReverseTriangulateIndices32(const uint32_t* indices, size_t indexCount, MeshMode mode);
+            std::vector<uint16_t> GLTFSDK_API ReverseTriangulateIndices16(const uint16_t* indices, size_t indexCount, MeshMode mode);
+            std::vector<uint32_t> GLTFSDK_API ReverseTriangulateIndices32(const uint32_t* indices, size_t indexCount, MeshMode mode);
 
-            std::vector<uint16_t> GLTFSDK_CDECL ReverseTriangulateIndices16(const std::vector<uint16_t>& indices, MeshMode mode);
-            std::vector<uint32_t> GLTFSDK_CDECL ReverseTriangulateIndices32(const std::vector<uint32_t>& indices, MeshMode mode);
+            std::vector<uint16_t> GLTFSDK_API ReverseTriangulateIndices16(const std::vector<uint16_t>& indices, MeshMode mode);
+            std::vector<uint32_t> GLTFSDK_API ReverseTriangulateIndices32(const std::vector<uint32_t>& indices, MeshMode mode);
 
-            std::vector<uint16_t> GLTFSDK_CDECL ReverseSegmentIndices16(const uint16_t* indices, size_t indexCount, MeshMode mode);
-            std::vector<uint32_t> GLTFSDK_CDECL ReverseSegmentIndices32(const uint32_t* indices, size_t indexCount, MeshMode mode);
+            std::vector<uint16_t> GLTFSDK_API ReverseSegmentIndices16(const uint16_t* indices, size_t indexCount, MeshMode mode);
+            std::vector<uint32_t> GLTFSDK_API ReverseSegmentIndices32(const uint32_t* indices, size_t indexCount, MeshMode mode);
 
-            std::vector<uint16_t> GLTFSDK_CDECL ReverseSegmentIndices16(const std::vector<uint16_t>& indices, MeshMode mode);
-            std::vector<uint32_t> GLTFSDK_CDECL ReverseSegmentIndices32(const std::vector<uint32_t>& indices, MeshMode mode);
+            std::vector<uint16_t> GLTFSDK_API ReverseSegmentIndices16(const std::vector<uint16_t>& indices, MeshMode mode);
+            std::vector<uint32_t> GLTFSDK_API ReverseSegmentIndices32(const std::vector<uint32_t>& indices, MeshMode mode);
         };
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/PBRUtils.h
+++ b/GLTFSDK/Inc/GLTFSDK/PBRUtils.h
@@ -48,7 +48,7 @@ namespace Microsoft
                 return std::sqrt(r + g + b);
             }
 
-            float GLTFSDK_CDECL SolveMetallic(float dielectricSpecular, float diffuse, float specular, float oneMinusSpecularStrength);
+            float GLTFSDK_API SolveMetallic(float dielectricSpecular, float diffuse, float specular, float oneMinusSpecularStrength);
         }
 
         template<typename TColor>
@@ -131,7 +131,7 @@ namespace Microsoft
             return mr;
         }
 
-        MetallicRoughnessValue GLTFSDK_CDECL SGToMR(const SpecularGlossinessValue& sg);
+        MetallicRoughnessValue GLTFSDK_API SGToMR(const SpecularGlossinessValue& sg);
 
         template<typename TColor>
         inline SpecularGlossinessValueTypeless<TColor> MRToSG(const MetallicRoughnessValueTypeless<TColor>& mr)
@@ -152,6 +152,6 @@ namespace Microsoft
             return sg;
         }
 
-        SpecularGlossinessValue GLTFSDK_CDECL MRToSG(const MetallicRoughnessValue& mr);
+        SpecularGlossinessValue GLTFSDK_API MRToSG(const MetallicRoughnessValue& mr);
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/PBRUtils.h
+++ b/GLTFSDK/Inc/GLTFSDK/PBRUtils.h
@@ -48,7 +48,7 @@ namespace Microsoft
                 return std::sqrt(r + g + b);
             }
 
-            float SolveMetallic(float dielectricSpecular, float diffuse, float specular, float oneMinusSpecularStrength);
+            float GLTFSDK_CDECL SolveMetallic(float dielectricSpecular, float diffuse, float specular, float oneMinusSpecularStrength);
         }
 
         template<typename TColor>
@@ -131,7 +131,7 @@ namespace Microsoft
             return mr;
         }
 
-        MetallicRoughnessValue SGToMR(const SpecularGlossinessValue& sg);
+        MetallicRoughnessValue GLTFSDK_CDECL SGToMR(const SpecularGlossinessValue& sg);
 
         template<typename TColor>
         inline SpecularGlossinessValueTypeless<TColor> MRToSG(const MetallicRoughnessValueTypeless<TColor>& mr)
@@ -152,6 +152,6 @@ namespace Microsoft
             return sg;
         }
 
-        SpecularGlossinessValue MRToSG(const MetallicRoughnessValue& mr);
+        SpecularGlossinessValue GLTFSDK_CDECL MRToSG(const MetallicRoughnessValue& mr);
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/Schema.h
+++ b/GLTFSDK/Inc/GLTFSDK/Schema.h
@@ -47,7 +47,7 @@ namespace Microsoft
         constexpr const char SCHEMA_URI_EXTENSION[] = "extension.schema.json";
         constexpr const char SCHEMA_URI_EXTRAS[] = "extras.schema.json";
 
-        const std::unordered_map<std::string, std::string>& GLTFSDK_CDECL GetDefaultSchemaUriMap();
+        const std::unordered_map<std::string, std::string>& GLTFSDK_API GetDefaultSchemaUriMap();
 
         enum class SchemaFlags : uint64_t
         {
@@ -92,6 +92,6 @@ namespace Microsoft
         SchemaFlags  operator& (SchemaFlags lhs,  SchemaFlags rhs);
         SchemaFlags& operator&=(SchemaFlags& lhs, SchemaFlags rhs);
 
-        std::unique_ptr<const class ISchemaLocator> GLTFSDK_CDECL GetDefaultSchemaLocator(SchemaFlags schemaFlags);
+        std::unique_ptr<const class ISchemaLocator> GLTFSDK_API GetDefaultSchemaLocator(SchemaFlags schemaFlags);
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/Schema.h
+++ b/GLTFSDK/Inc/GLTFSDK/Schema.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <GLTFSDK/Definitions.h>
+
 #include <string>
 #include <memory>
 #include <unordered_map>
@@ -45,7 +47,7 @@ namespace Microsoft
         constexpr const char SCHEMA_URI_EXTENSION[] = "extension.schema.json";
         constexpr const char SCHEMA_URI_EXTRAS[] = "extras.schema.json";
 
-        const std::unordered_map<std::string, std::string>& GetDefaultSchemaUriMap();
+        const std::unordered_map<std::string, std::string>& GLTFSDK_CDECL GetDefaultSchemaUriMap();
 
         enum class SchemaFlags : uint64_t
         {
@@ -90,6 +92,6 @@ namespace Microsoft
         SchemaFlags  operator& (SchemaFlags lhs,  SchemaFlags rhs);
         SchemaFlags& operator&=(SchemaFlags& lhs, SchemaFlags rhs);
 
-        std::unique_ptr<const class ISchemaLocator> GetDefaultSchemaLocator(SchemaFlags schemaFlags);
+        std::unique_ptr<const class ISchemaLocator> GLTFSDK_CDECL GetDefaultSchemaLocator(SchemaFlags schemaFlags);
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/SchemaValidation.h
+++ b/GLTFSDK/Inc/GLTFSDK/SchemaValidation.h
@@ -16,6 +16,6 @@ namespace Microsoft
             virtual const char* GetSchemaContent(const std::string& uri) const = 0;
         };
 
-        void GLTFSDK_CDECL ValidateDocumentAgainstSchema(const rapidjson::Document& d, const std::string& schemaUri, std::unique_ptr<const ISchemaLocator> schemaLocator);
+        void GLTFSDK_API ValidateDocumentAgainstSchema(const rapidjson::Document& d, const std::string& schemaUri, std::unique_ptr<const ISchemaLocator> schemaLocator);
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/SchemaValidation.h
+++ b/GLTFSDK/Inc/GLTFSDK/SchemaValidation.h
@@ -16,6 +16,6 @@ namespace Microsoft
             virtual const char* GetSchemaContent(const std::string& uri) const = 0;
         };
 
-        void ValidateDocumentAgainstSchema(const rapidjson::Document& d, const std::string& schemaUri, std::unique_ptr<const ISchemaLocator> schemaLocator);
+        void GLTFSDK_CDECL ValidateDocumentAgainstSchema(const rapidjson::Document& d, const std::string& schemaUri, std::unique_ptr<const ISchemaLocator> schemaLocator);
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/Serialize.h
+++ b/GLTFSDK/Inc/GLTFSDK/Serialize.h
@@ -3,9 +3,11 @@
 
 #pragma once
 
+#include <GLTFSDK/Definitions.h>
+
 #include <string>
 
-namespace Microsoft 
+namespace Microsoft
 {
     namespace glTF
     {
@@ -23,7 +25,7 @@ namespace Microsoft
         class Document;
         class ExtensionSerializer;
 
-        std::string Serialize(const Document& gltfDocument, SerializeFlags flags = SerializeFlags::None);
-        std::string Serialize(const Document& gltfDocument, const ExtensionSerializer& extensionHandler, SerializeFlags flags = SerializeFlags::None);
+        std::string GLTFSDK_CDECL Serialize(const Document& gltfDocument, SerializeFlags flags = SerializeFlags::None);
+        std::string GLTFSDK_CDECL Serialize(const Document& gltfDocument, const ExtensionSerializer& extensionHandler, SerializeFlags flags = SerializeFlags::None);
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/Serialize.h
+++ b/GLTFSDK/Inc/GLTFSDK/Serialize.h
@@ -25,7 +25,7 @@ namespace Microsoft
         class Document;
         class ExtensionSerializer;
 
-        std::string GLTFSDK_CDECL Serialize(const Document& gltfDocument, SerializeFlags flags = SerializeFlags::None);
-        std::string GLTFSDK_CDECL Serialize(const Document& gltfDocument, const ExtensionSerializer& extensionHandler, SerializeFlags flags = SerializeFlags::None);
+        std::string GLTFSDK_API Serialize(const Document& gltfDocument, SerializeFlags flags = SerializeFlags::None);
+        std::string GLTFSDK_API Serialize(const Document& gltfDocument, const ExtensionSerializer& extensionHandler, SerializeFlags flags = SerializeFlags::None);
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/Validation.h
+++ b/GLTFSDK/Inc/GLTFSDK/Validation.h
@@ -13,18 +13,18 @@ namespace Microsoft
     {
         namespace Validation
         {
-            void Validate(const Document& doc);
-            void ValidateAccessors(const Document& doc);
-            void ValidateMeshes(const Document& doc);
-            void ValidateMeshPrimitive(const Document& doc, const MeshPrimitive& primitive);
-            void ValidateMeshPrimitiveAttributeAccessors(const Document& doc, const std::unordered_map<std::string, std::string>& attributes, const size_t vertexCount);
-            void ValidateAccessorTypes(const Accessor& accessor, const std::string& accessorName,
+            void GLTFSDK_CDECL Validate(const Document& doc);
+            void GLTFSDK_CDECL ValidateAccessors(const Document& doc);
+            void GLTFSDK_CDECL ValidateMeshes(const Document& doc);
+            void GLTFSDK_CDECL ValidateMeshPrimitive(const Document& doc, const MeshPrimitive& primitive);
+            void GLTFSDK_CDECL ValidateMeshPrimitiveAttributeAccessors(const Document& doc, const std::unordered_map<std::string, std::string>& attributes, const size_t vertexCount);
+            void GLTFSDK_CDECL ValidateAccessorTypes(const Accessor& accessor, const std::string& accessorName,
                 const std::set<AccessorType>& accessorTypes, const std::set<ComponentType>& componentTypes);
-            void ValidateAccessor(const Document& doc, const Accessor& accessor);
-            void ValidateBufferView(const BufferView& buffer_view, const Buffer& buffer);
+            void GLTFSDK_CDECL ValidateAccessor(const Document& doc, const Accessor& accessor);
+            void GLTFSDK_CDECL ValidateBufferView(const BufferView& buffer_view, const Buffer& buffer);
 
-            bool SafeAddition(size_t a, size_t b, size_t& result);
-            bool SafeMultiplication(size_t a, size_t b, size_t& result);
+            bool GLTFSDK_CDECL SafeAddition(size_t a, size_t b, size_t& result);
+            bool GLTFSDK_CDECL SafeMultiplication(size_t a, size_t b, size_t& result);
         };
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/Validation.h
+++ b/GLTFSDK/Inc/GLTFSDK/Validation.h
@@ -13,18 +13,18 @@ namespace Microsoft
     {
         namespace Validation
         {
-            void GLTFSDK_CDECL Validate(const Document& doc);
-            void GLTFSDK_CDECL ValidateAccessors(const Document& doc);
-            void GLTFSDK_CDECL ValidateMeshes(const Document& doc);
-            void GLTFSDK_CDECL ValidateMeshPrimitive(const Document& doc, const MeshPrimitive& primitive);
-            void GLTFSDK_CDECL ValidateMeshPrimitiveAttributeAccessors(const Document& doc, const std::unordered_map<std::string, std::string>& attributes, const size_t vertexCount);
-            void GLTFSDK_CDECL ValidateAccessorTypes(const Accessor& accessor, const std::string& accessorName,
+            void GLTFSDK_API Validate(const Document& doc);
+            void GLTFSDK_API ValidateAccessors(const Document& doc);
+            void GLTFSDK_API ValidateMeshes(const Document& doc);
+            void GLTFSDK_API ValidateMeshPrimitive(const Document& doc, const MeshPrimitive& primitive);
+            void GLTFSDK_API ValidateMeshPrimitiveAttributeAccessors(const Document& doc, const std::unordered_map<std::string, std::string>& attributes, const size_t vertexCount);
+            void GLTFSDK_API ValidateAccessorTypes(const Accessor& accessor, const std::string& accessorName,
                 const std::set<AccessorType>& accessorTypes, const std::set<ComponentType>& componentTypes);
-            void GLTFSDK_CDECL ValidateAccessor(const Document& doc, const Accessor& accessor);
-            void GLTFSDK_CDECL ValidateBufferView(const BufferView& buffer_view, const Buffer& buffer);
+            void GLTFSDK_API ValidateAccessor(const Document& doc, const Accessor& accessor);
+            void GLTFSDK_API ValidateBufferView(const BufferView& buffer_view, const Buffer& buffer);
 
-            bool GLTFSDK_CDECL SafeAddition(size_t a, size_t b, size_t& result);
-            bool GLTFSDK_CDECL SafeMultiplication(size_t a, size_t b, size_t& result);
+            bool GLTFSDK_API SafeAddition(size_t a, size_t b, size_t& result);
+            bool GLTFSDK_API SafeMultiplication(size_t a, size_t b, size_t& result);
         };
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/Version.h
+++ b/GLTFSDK/Inc/GLTFSDK/Version.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <GLTFSDK/Definitions.h>
+
 #include <tuple>
 #include <string>
 
@@ -33,7 +35,7 @@ namespace Microsoft
             bool operator==(const Version& rhs) const;
             bool operator!=(const Version& rhs) const;
 
-            static std::tuple<uint32_t, uint32_t> AsTuple(const char* version);
+            static std::tuple<uint32_t, uint32_t> GLTFSDK_CDECL AsTuple(const char* version);
         };
 
         namespace Versions
@@ -41,7 +43,7 @@ namespace Microsoft
             constexpr Version v2_0 = { 2U, 0U };
         }
 
-        bool IsMinVersionRequirementSatisfied(const Version& minVersion, std::initializer_list<Version> supported = { Versions::v2_0 });
-        bool IsMinVersionRequirementSatisfied(const std::string& minVersion, std::initializer_list<Version> supported = { Versions::v2_0 });
+        bool GLTFSDK_CDECL IsMinVersionRequirementSatisfied(const Version& minVersion, std::initializer_list<Version> supported = { Versions::v2_0 });
+        bool GLTFSDK_CDECL IsMinVersionRequirementSatisfied(const std::string& minVersion, std::initializer_list<Version> supported = { Versions::v2_0 });
     }
 }

--- a/GLTFSDK/Inc/GLTFSDK/Version.h
+++ b/GLTFSDK/Inc/GLTFSDK/Version.h
@@ -35,7 +35,7 @@ namespace Microsoft
             bool operator==(const Version& rhs) const;
             bool operator!=(const Version& rhs) const;
 
-            static std::tuple<uint32_t, uint32_t> GLTFSDK_CDECL AsTuple(const char* version);
+            static std::tuple<uint32_t, uint32_t> GLTFSDK_API AsTuple(const char* version);
         };
 
         namespace Versions
@@ -43,7 +43,7 @@ namespace Microsoft
             constexpr Version v2_0 = { 2U, 0U };
         }
 
-        bool GLTFSDK_CDECL IsMinVersionRequirementSatisfied(const Version& minVersion, std::initializer_list<Version> supported = { Versions::v2_0 });
-        bool GLTFSDK_CDECL IsMinVersionRequirementSatisfied(const std::string& minVersion, std::initializer_list<Version> supported = { Versions::v2_0 });
+        bool GLTFSDK_API IsMinVersionRequirementSatisfied(const Version& minVersion, std::initializer_list<Version> supported = { Versions::v2_0 });
+        bool GLTFSDK_API IsMinVersionRequirementSatisfied(const std::string& minVersion, std::initializer_list<Version> supported = { Versions::v2_0 });
     }
 }

--- a/GLTFSDK/Source/AnimationUtils.cpp
+++ b/GLTFSDK/Source/AnimationUtils.cpp
@@ -8,7 +8,7 @@
 
 using namespace Microsoft::glTF;
 
-std::vector<float> AnimationUtils::GetKeyframeTimes(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
+std::vector<float> GLTFSDK_API AnimationUtils::GetKeyframeTimes(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
 {
     if (accessor.type != TYPE_SCALAR)
     {
@@ -23,13 +23,13 @@ std::vector<float> AnimationUtils::GetKeyframeTimes(const Document& doc, const G
     return reader.ReadBinaryData<float>(doc, accessor);
 }
 
-std::vector<float> AnimationUtils::GetKeyframeTimes(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler)
+std::vector<float> GLTFSDK_API AnimationUtils::GetKeyframeTimes(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler)
 {
     auto& accessor = doc.accessors[sampler.inputAccessorId];
     return GetKeyframeTimes(doc, reader, accessor);
 }
 
-std::vector<float> AnimationUtils::GetInverseBindMatrices(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
+std::vector<float> GLTFSDK_API AnimationUtils::GetInverseBindMatrices(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
 {
     if (accessor.type != TYPE_MAT4)
     {
@@ -44,13 +44,13 @@ std::vector<float> AnimationUtils::GetInverseBindMatrices(const Document& doc, c
     return reader.ReadBinaryData<float>(doc, accessor);
 }
 
-std::vector<float> AnimationUtils::GetInverseBindMatrices(const Document& doc, const GLTFResourceReader& reader, const Skin& skin)
+std::vector<float> GLTFSDK_API AnimationUtils::GetInverseBindMatrices(const Document& doc, const GLTFResourceReader& reader, const Skin& skin)
 {
     auto& accessor = doc.accessors[skin.inverseBindMatricesAccessorId];
     return GetInverseBindMatrices(doc, reader, accessor);
 }
 
-std::vector<float> AnimationUtils::GetTranslations(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
+std::vector<float> GLTFSDK_API AnimationUtils::GetTranslations(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
 {
     if (accessor.type != TYPE_VEC3)
     {
@@ -65,13 +65,13 @@ std::vector<float> AnimationUtils::GetTranslations(const Document& doc, const GL
     return reader.ReadBinaryData<float>(doc, accessor);
 }
 
-std::vector<float> AnimationUtils::GetTranslations(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler)
+std::vector<float> GLTFSDK_API AnimationUtils::GetTranslations(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler)
 {
     auto& accessor = doc.accessors[sampler.outputAccessorId];
     return GetTranslations(doc, reader, accessor);
 }
 
-std::vector<float> AnimationUtils::GetRotations(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
+std::vector<float> GLTFSDK_API AnimationUtils::GetRotations(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
 {
     if (accessor.type != TYPE_VEC4)
     {
@@ -81,13 +81,13 @@ std::vector<float> AnimationUtils::GetRotations(const Document& doc, const GLTFR
     return reader.ReadFloatData(doc, accessor);
 }
 
-std::vector<float> AnimationUtils::GetRotations(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler)
+std::vector<float> GLTFSDK_API AnimationUtils::GetRotations(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler)
 {
     auto& accessor = doc.accessors[sampler.outputAccessorId];
     return GetRotations(doc, reader, accessor);
 }
 
-std::vector<float> AnimationUtils::GetScales(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
+std::vector<float> GLTFSDK_API AnimationUtils::GetScales(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
 {
     if (accessor.type != TYPE_VEC3)
     {
@@ -102,13 +102,13 @@ std::vector<float> AnimationUtils::GetScales(const Document& doc, const GLTFReso
     return reader.ReadBinaryData<float>(doc, accessor);
 }
 
-std::vector<float> AnimationUtils::GetScales(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler)
+std::vector<float> GLTFSDK_API AnimationUtils::GetScales(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler)
 {
     auto& accessor = doc.accessors[sampler.outputAccessorId];
     return GetScales(doc, reader, accessor);
 }
 
-std::vector<float> AnimationUtils::GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
+std::vector<float> GLTFSDK_API AnimationUtils::GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
 {
     if (accessor.type != TYPE_SCALAR)
     {
@@ -118,7 +118,7 @@ std::vector<float> AnimationUtils::GetMorphWeights(const Document& doc, const GL
     return reader.ReadFloatData(doc, accessor);
 }
 
-std::vector<float> AnimationUtils::GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler)
+std::vector<float> GLTFSDK_API AnimationUtils::GetMorphWeights(const Document& doc, const GLTFResourceReader& reader, const AnimationSampler& sampler)
 {
     auto& accessor = doc.accessors[sampler.outputAccessorId];
     return GetMorphWeights(doc, reader, accessor);

--- a/GLTFSDK/Source/Color.cpp
+++ b/GLTFSDK/Source/Color.cpp
@@ -163,14 +163,14 @@ Color3 Color3::Clamp(const Color3& color, float lo, float hi)
     };
 }
 
-bool Microsoft::glTF::operator==(const Color3& lhs, const Color3& rhs)
+bool GLTFSDK_API Microsoft::glTF::operator==(const Color3& lhs, const Color3& rhs)
 {
     return lhs.r == rhs.r
         && lhs.g == rhs.g
         && lhs.b == rhs.b;
 }
 
-bool Microsoft::glTF::operator!=(const Color3& lhs, const Color3& rhs)
+bool GLTFSDK_API Microsoft::glTF::operator!=(const Color3& lhs, const Color3& rhs)
 {
     return !(lhs == rhs);
 }
@@ -333,7 +333,7 @@ Color4 Color4::Clamp(const Color4& color, float lo, float hi)
     };
 }
 
-bool Microsoft::glTF::operator==(const Color4& lhs, const Color4& rhs)
+bool GLTFSDK_API Microsoft::glTF::operator==(const Color4& lhs, const Color4& rhs)
 {
     return lhs.r == rhs.r
         && lhs.g == rhs.g
@@ -341,7 +341,7 @@ bool Microsoft::glTF::operator==(const Color4& lhs, const Color4& rhs)
         && lhs.a == rhs.a;
 }
 
-bool Microsoft::glTF::operator!=(const Color4& lhs, const Color4& rhs)
+bool GLTFSDK_API Microsoft::glTF::operator!=(const Color4& lhs, const Color4& rhs)
 {
     return !(lhs == rhs);
 }

--- a/GLTFSDK/Source/Deserialize.cpp
+++ b/GLTFSDK/Source/Deserialize.cpp
@@ -834,12 +834,12 @@ namespace
     }
 }
 
-Document Microsoft::glTF::Deserialize(const std::string& json, DeserializeFlags flags, SchemaFlags schemaFlags)
+Document GLTFSDK_API Microsoft::glTF::Deserialize(const std::string& json, DeserializeFlags flags, SchemaFlags schemaFlags)
 {
     return Deserialize(json, ExtensionDeserializer(), flags, schemaFlags);
 }
 
-Document Microsoft::glTF::Deserialize(const std::string& json, const ExtensionDeserializer& extensionDeserializer, DeserializeFlags flags, SchemaFlags schemaFlags)
+Document GLTFSDK_API Microsoft::glTF::Deserialize(const std::string& json, const ExtensionDeserializer& extensionDeserializer, DeserializeFlags flags, SchemaFlags schemaFlags)
 {
     const auto document = HasFlag(flags, DeserializeFlags::IgnoreByteOrderMark) ?
         RapidJsonUtils::CreateDocumentFromEncodedString(json) :
@@ -848,12 +848,12 @@ Document Microsoft::glTF::Deserialize(const std::string& json, const ExtensionDe
     return DeserializeInternal(document, extensionDeserializer, schemaFlags);
 }
 
-Document Microsoft::glTF::Deserialize(std::istream& jsonStream, DeserializeFlags flags, SchemaFlags schemaFlags)
+Document GLTFSDK_API Microsoft::glTF::Deserialize(std::istream& jsonStream, DeserializeFlags flags, SchemaFlags schemaFlags)
 {
     return Deserialize(jsonStream, ExtensionDeserializer(), flags, schemaFlags);
 }
 
-Document Microsoft::glTF::Deserialize(std::istream& jsonStream, const ExtensionDeserializer& extensionDeserializer, DeserializeFlags flags, SchemaFlags schemaFlags)
+Document GLTFSDK_API Microsoft::glTF::Deserialize(std::istream& jsonStream, const ExtensionDeserializer& extensionDeserializer, DeserializeFlags flags, SchemaFlags schemaFlags)
 {
     const auto document = HasFlag(flags, DeserializeFlags::IgnoreByteOrderMark) ?
         RapidJsonUtils::CreateDocumentFromEncodedStream(jsonStream) :

--- a/GLTFSDK/Source/ExtensionsKHR.cpp
+++ b/GLTFSDK/Source/ExtensionsKHR.cpp
@@ -200,7 +200,7 @@ bool KHR::Materials::PBRSpecularGlossiness::IsEqual(const Extension& rhs) const
         && this->specularGlossinessTexture == other->specularGlossinessTexture;
 }
 
-std::string KHR::Materials::SerializePBRSpecGloss(const Materials::PBRSpecularGlossiness& specGloss, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
+std::string GLTFSDK_API KHR::Materials::SerializePBRSpecGloss(const Materials::PBRSpecularGlossiness& specGloss, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
 {
     rapidjson::Document doc;
     auto& a = doc.GetAllocator();
@@ -245,7 +245,7 @@ std::string KHR::Materials::SerializePBRSpecGloss(const Materials::PBRSpecularGl
     return buffer.GetString();
 }
 
-std::unique_ptr<Extension> KHR::Materials::DeserializePBRSpecGloss(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
+std::unique_ptr<Extension> GLTFSDK_API KHR::Materials::DeserializePBRSpecGloss(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
 {
     Materials::PBRSpecularGlossiness specGloss;
 
@@ -314,7 +314,7 @@ bool KHR::Materials::Unlit::IsEqual(const Extension& rhs) const
     return dynamic_cast<const Unlit*>(&rhs) != nullptr;
 }
 
-std::string KHR::Materials::SerializeUnlit(const Materials::Unlit& extension, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
+std::string GLTFSDK_API KHR::Materials::SerializeUnlit(const Materials::Unlit& extension, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
 {
     rapidjson::Document doc;
     auto& a = doc.GetAllocator();
@@ -329,7 +329,7 @@ std::string KHR::Materials::SerializeUnlit(const Materials::Unlit& extension, co
     return buffer.GetString();
 }
 
-std::unique_ptr<Extension> KHR::Materials::DeserializeUnlit(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
+std::unique_ptr<Extension> GLTFSDK_API KHR::Materials::DeserializeUnlit(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
 {
     Unlit unlit;
 
@@ -367,7 +367,7 @@ bool KHR::Materials::Clearcoat::IsEqual(const Extension& rhs) const
         && this->normalTexture == other->normalTexture;
 }
 
-std::string KHR::Materials::SerializeClearcoat(const Materials::Clearcoat& clearcoat, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
+std::string GLTFSDK_API KHR::Materials::SerializeClearcoat(const Materials::Clearcoat& clearcoat, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
 {
     rapidjson::Document doc;
     auto& a = doc.GetAllocator();
@@ -414,7 +414,7 @@ std::string KHR::Materials::SerializeClearcoat(const Materials::Clearcoat& clear
     return buffer.GetString();
 }
 
-std::unique_ptr<Extension> KHR::Materials::DeserializeClearcoat(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
+std::unique_ptr<Extension> GLTFSDK_API KHR::Materials::DeserializeClearcoat(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
 {
     Materials::Clearcoat clearcoat;
 
@@ -487,7 +487,7 @@ bool KHR::Materials::Volume::IsEqual(const Extension& rhs) const
         && this->thicknessTexture == other->thicknessTexture;
 }
 
-std::string KHR::Materials::SerializeVolume(const Materials::Volume& volume, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
+std::string GLTFSDK_API KHR::Materials::SerializeVolume(const Materials::Volume& volume, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
 {
     rapidjson::Document doc;
     auto& a = doc.GetAllocator();
@@ -525,7 +525,7 @@ std::string KHR::Materials::SerializeVolume(const Materials::Volume& volume, con
     return buffer.GetString();
 }
 
-std::unique_ptr<Extension> KHR::Materials::DeserializeVolume(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
+std::unique_ptr<Extension> GLTFSDK_API KHR::Materials::DeserializeVolume(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
 {
     Materials::Volume volume;
 
@@ -599,7 +599,7 @@ bool KHR::Materials::Iridescence::IsEqual(const Extension& rhs) const
         && this->thicknessTexture == other->thicknessTexture;
 }
 
-std::string KHR::Materials::SerializeIridescence(const Materials::Iridescence& iridescence, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
+std::string GLTFSDK_API KHR::Materials::SerializeIridescence(const Materials::Iridescence& iridescence, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
 {
     rapidjson::Document doc;
     auto& a = doc.GetAllocator();
@@ -649,7 +649,7 @@ std::string KHR::Materials::SerializeIridescence(const Materials::Iridescence& i
     return buffer.GetString();
 }
 
-std::unique_ptr<Extension> KHR::Materials::DeserializeIridescence(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
+std::unique_ptr<Extension> GLTFSDK_API KHR::Materials::DeserializeIridescence(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
 {
     Materials::Iridescence iridescence;
 
@@ -725,7 +725,7 @@ bool KHR::Materials::Transmission::IsEqual(const Extension& rhs) const
         && this->texture == other->texture;
 }
 
-std::string KHR::Materials::SerializeTransmission(const Materials::Transmission& transmission, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
+std::string GLTFSDK_API KHR::Materials::SerializeTransmission(const Materials::Transmission& transmission, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
 {
     rapidjson::Document doc;
     auto& a = doc.GetAllocator();
@@ -753,7 +753,7 @@ std::string KHR::Materials::SerializeTransmission(const Materials::Transmission&
     return buffer.GetString();
 }
 
-std::unique_ptr<Extension> KHR::Materials::DeserializeTransmission(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
+std::unique_ptr<Extension> GLTFSDK_API KHR::Materials::DeserializeTransmission(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
 {
     Materials::Transmission transmission;
 
@@ -804,7 +804,7 @@ bool KHR::Materials::Sheen::IsEqual(const Extension& rhs) const
         && this->roughnessTexture == other->roughnessTexture;
 }
 
-std::string KHR::Materials::SerializeSheen(const Materials::Sheen& sheen, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
+std::string GLTFSDK_API KHR::Materials::SerializeSheen(const Materials::Sheen& sheen, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
 {
     rapidjson::Document doc;
     auto& a = doc.GetAllocator();
@@ -844,7 +844,7 @@ std::string KHR::Materials::SerializeSheen(const Materials::Sheen& sheen, const 
     return buffer.GetString();
 }
 
-std::unique_ptr<Extension> KHR::Materials::DeserializeSheen(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
+std::unique_ptr<Extension> GLTFSDK_API KHR::Materials::DeserializeSheen(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
 {
     Materials::Sheen sheen;
 
@@ -914,7 +914,7 @@ bool KHR::Materials::Specular::IsEqual(const Extension& rhs) const
         && this->texture == other->texture;
 }
 
-std::string KHR::Materials::SerializeSpecular(const Materials::Specular& specular, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
+std::string GLTFSDK_API KHR::Materials::SerializeSpecular(const Materials::Specular& specular, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
 {
     rapidjson::Document doc;
     auto& a = doc.GetAllocator();
@@ -954,7 +954,7 @@ std::string KHR::Materials::SerializeSpecular(const Materials::Specular& specula
     return buffer.GetString();
 }
 
-std::unique_ptr<Extension> KHR::Materials::DeserializeSpecular(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
+std::unique_ptr<Extension> GLTFSDK_API KHR::Materials::DeserializeSpecular(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
 {
     Materials::Specular specular;
 
@@ -1016,7 +1016,7 @@ bool KHR::MeshPrimitives::DracoMeshCompression::IsEqual(const Extension& rhs) co
         && this->attributes == other->attributes;
 }
 
-std::string KHR::MeshPrimitives::SerializeDracoMeshCompression(const MeshPrimitives::DracoMeshCompression& dracoMeshCompression, const Document& glTFdoc, const ExtensionSerializer& extensionSerializer)
+std::string GLTFSDK_API KHR::MeshPrimitives::SerializeDracoMeshCompression(const MeshPrimitives::DracoMeshCompression& dracoMeshCompression, const Document& glTFdoc, const ExtensionSerializer& extensionSerializer)
 {
     rapidjson::Document doc;
     auto& a = doc.GetAllocator();
@@ -1048,7 +1048,7 @@ std::string KHR::MeshPrimitives::SerializeDracoMeshCompression(const MeshPrimiti
     return buffer.GetString();
 }
 
-std::unique_ptr<Extension> KHR::MeshPrimitives::DeserializeDracoMeshCompression(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
+std::unique_ptr<Extension> GLTFSDK_API KHR::MeshPrimitives::DeserializeDracoMeshCompression(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
 {
     auto extension = std::make_unique<DracoMeshCompression>();
 
@@ -1102,7 +1102,7 @@ bool KHR::Nodes::MeshGPUInstancing::IsEqual(const Extension& rhs) const
         && glTFProperty::Equals(*this, *other);
 }
 
-std::string KHR::Nodes::SerializeMeshGPUInstancing(const Nodes::MeshGPUInstancing& instancing, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
+std::string GLTFSDK_API KHR::Nodes::SerializeMeshGPUInstancing(const Nodes::MeshGPUInstancing& instancing, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
 {
     rapidjson::Document doc;
     auto& a = doc.GetAllocator();
@@ -1126,7 +1126,7 @@ std::string KHR::Nodes::SerializeMeshGPUInstancing(const Nodes::MeshGPUInstancin
     return buffer.GetString();
 }
 
-std::unique_ptr<Extension> KHR::Nodes::DeserializeMeshGPUInstancing(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
+std::unique_ptr<Extension> GLTFSDK_API KHR::Nodes::DeserializeMeshGPUInstancing(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
 {
     Nodes::MeshGPUInstancing instancing;
 
@@ -1185,7 +1185,7 @@ bool KHR::TextureInfos::TextureTransform::IsEqual(const Extension& rhs) const
         && this->texCoord == other->texCoord;
 }
 
-std::string KHR::TextureInfos::SerializeTextureTransform(const TextureTransform& textureTransform, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
+std::string GLTFSDK_API KHR::TextureInfos::SerializeTextureTransform(const TextureTransform& textureTransform, const Document& gltfDocument, const ExtensionSerializer& extensionSerializer)
 {
     rapidjson::Document doc;
     auto& a = doc.GetAllocator();
@@ -1221,7 +1221,7 @@ std::string KHR::TextureInfos::SerializeTextureTransform(const TextureTransform&
     return buffer.GetString();
 }
 
-std::unique_ptr<Extension> KHR::TextureInfos::DeserializeTextureTransform(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
+std::unique_ptr<Extension> GLTFSDK_API KHR::TextureInfos::DeserializeTextureTransform(const std::string& json, const ExtensionDeserializer& extensionDeserializer)
 {
     TextureTransform textureTransform;
 

--- a/GLTFSDK/Source/ExtensionsKHR.cpp
+++ b/GLTFSDK/Source/ExtensionsKHR.cpp
@@ -125,7 +125,7 @@ namespace
     }
 }
 
-ExtensionSerializer KHR::GetKHRExtensionSerializer()
+ExtensionSerializer GLTFSDK_API KHR::GetKHRExtensionSerializer()
 {
     using namespace Materials;
     using namespace MeshPrimitives;
@@ -149,7 +149,7 @@ ExtensionSerializer KHR::GetKHRExtensionSerializer()
     return extensionSerializer;
 }
 
-ExtensionDeserializer KHR::GetKHRExtensionDeserializer()
+ExtensionDeserializer GLTFSDK_API KHR::GetKHRExtensionDeserializer()
 {
     using namespace Materials;
     using namespace MeshPrimitives;

--- a/GLTFSDK/Source/MeshPrimitiveUtils.cpp
+++ b/GLTFSDK/Source/MeshPrimitiveUtils.cpp
@@ -512,7 +512,7 @@ namespace
     }
 }
 
-std::vector<uint16_t> MeshPrimitiveUtils::GetIndices16(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
+std::vector<uint16_t> GLTFSDK_API MeshPrimitiveUtils::GetIndices16(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
 {
     if (accessor.type != TYPE_SCALAR)
     {
@@ -535,13 +535,13 @@ std::vector<uint16_t> MeshPrimitiveUtils::GetIndices16(const Document& doc, cons
     }
 }
 
-std::vector<uint16_t> MeshPrimitiveUtils::GetIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<uint16_t> GLTFSDK_API MeshPrimitiveUtils::GetIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
     const auto& accessor = doc.accessors.Get(meshPrimitive.indicesAccessorId);
     return GetIndices16(doc, reader, accessor);
 }
 
-std::vector<uint32_t> MeshPrimitiveUtils::GetIndices32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
+std::vector<uint32_t> GLTFSDK_API MeshPrimitiveUtils::GetIndices32(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
 {
     if (accessor.type != TYPE_SCALAR)
     {
@@ -564,35 +564,35 @@ std::vector<uint32_t> MeshPrimitiveUtils::GetIndices32(const Document& doc, cons
     }
 }
 
-std::vector<uint32_t> MeshPrimitiveUtils::GetIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<uint32_t> GLTFSDK_API MeshPrimitiveUtils::GetIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
     const auto& accessor = doc.accessors.Get(meshPrimitive.indicesAccessorId);
     return GetIndices32(doc, reader, accessor);
 }
 
-std::vector<uint16_t> MeshPrimitiveUtils::GetTriangulatedIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<uint16_t> GLTFSDK_API MeshPrimitiveUtils::GetTriangulatedIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
     return GetTriangulatedIndices<uint16_t>(meshPrimitive.mode, GetOrCreateIndices16(doc, reader, meshPrimitive));
 }
 
-std::vector<uint32_t> MeshPrimitiveUtils::GetTriangulatedIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<uint32_t> GLTFSDK_API MeshPrimitiveUtils::GetTriangulatedIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
     return GetTriangulatedIndices<uint32_t>(meshPrimitive.mode, GetOrCreateIndices32(doc, reader, meshPrimitive));
 }
 
-std::vector<uint16_t> MeshPrimitiveUtils::GetSegmentedIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<uint16_t> GLTFSDK_API MeshPrimitiveUtils::GetSegmentedIndices16(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
 
     return GetSegmentedIndices<uint16_t>(meshPrimitive.mode, GetOrCreateIndices16(doc, reader, meshPrimitive));
 }
 
-std::vector<uint32_t> MeshPrimitiveUtils::GetSegmentedIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<uint32_t> GLTFSDK_API MeshPrimitiveUtils::GetSegmentedIndices32(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
     return GetSegmentedIndices<uint32_t>(meshPrimitive.mode, GetOrCreateIndices32(doc, reader, meshPrimitive));
 }
 
 // Positions
-std::vector<float> MeshPrimitiveUtils::GetPositions(const Document& doc, const GLTFResourceReader& reader, const Accessor& positionsAccessor)
+std::vector<float> GLTFSDK_API MeshPrimitiveUtils::GetPositions(const Document& doc, const GLTFResourceReader& reader, const Accessor& positionsAccessor)
 {
     if (positionsAccessor.type != TYPE_VEC3)
     {
@@ -607,20 +607,20 @@ std::vector<float> MeshPrimitiveUtils::GetPositions(const Document& doc, const G
     return reader.ReadFloatData(doc, positionsAccessor);
 }
 
-std::vector<float> MeshPrimitiveUtils::GetPositions(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<float> GLTFSDK_API MeshPrimitiveUtils::GetPositions(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
     const auto& positionsAccessor = doc.accessors.Get(meshPrimitive.GetAttributeAccessorId(ACCESSOR_POSITION));
     return GetPositions(doc, reader, positionsAccessor);
 }
 
-std::vector<float> MeshPrimitiveUtils::GetPositions(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget)
+std::vector<float> GLTFSDK_API MeshPrimitiveUtils::GetPositions(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget)
 {
     const auto& positionsAccessor = doc.accessors.Get(morphTarget.positionsAccessorId);
     return GetPositions(doc, reader, positionsAccessor);
 }
 
 // Normals
-std::vector<float> MeshPrimitiveUtils::GetNormals(const Document& doc, const GLTFResourceReader& reader, const Accessor& normalsAccessor)
+std::vector<float> GLTFSDK_API MeshPrimitiveUtils::GetNormals(const Document& doc, const GLTFResourceReader& reader, const Accessor& normalsAccessor)
 {
     if (normalsAccessor.type != TYPE_VEC3)
     {
@@ -635,20 +635,20 @@ std::vector<float> MeshPrimitiveUtils::GetNormals(const Document& doc, const GLT
     return reader.ReadFloatData(doc, normalsAccessor);
 }
 
-std::vector<float> MeshPrimitiveUtils::GetNormals(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<float> GLTFSDK_API MeshPrimitiveUtils::GetNormals(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
     const auto& accessor = doc.accessors.Get(meshPrimitive.GetAttributeAccessorId(ACCESSOR_NORMAL));
     return GetNormals(doc, reader, accessor);
 }
 
-std::vector<float> MeshPrimitiveUtils::GetNormals(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget)
+std::vector<float> GLTFSDK_API MeshPrimitiveUtils::GetNormals(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget)
 {
     const auto& accessor = doc.accessors.Get(morphTarget.normalsAccessorId);
     return GetNormals(doc, reader, accessor);
 }
 
 // Tangents
-std::vector<float> MeshPrimitiveUtils::GetTangents(const Document& doc, const GLTFResourceReader& reader, const Accessor& tangentsAccessor)
+std::vector<float> GLTFSDK_API MeshPrimitiveUtils::GetTangents(const Document& doc, const GLTFResourceReader& reader, const Accessor& tangentsAccessor)
 {
     if (tangentsAccessor.type != TYPE_VEC4)
     {
@@ -663,14 +663,14 @@ std::vector<float> MeshPrimitiveUtils::GetTangents(const Document& doc, const GL
     return reader.ReadFloatData(doc, tangentsAccessor);
 }
 
-std::vector<float> MeshPrimitiveUtils::GetTangents(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<float> GLTFSDK_API MeshPrimitiveUtils::GetTangents(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
     const auto& accessor = doc.accessors.Get(meshPrimitive.GetAttributeAccessorId(ACCESSOR_TANGENT));
     return GetTangents(doc, reader, accessor);
 }
 
 // Morph Target Tangents (which have a different accessor type than base mesh tangents)
-std::vector<float> MeshPrimitiveUtils::GetMorphTangents(const Document& doc, const GLTFResourceReader& reader, const Accessor& tangentsAccessor)
+std::vector<float> GLTFSDK_API MeshPrimitiveUtils::GetMorphTangents(const Document& doc, const GLTFResourceReader& reader, const Accessor& tangentsAccessor)
 {
     if (tangentsAccessor.type != TYPE_VEC3)
     {
@@ -685,14 +685,14 @@ std::vector<float> MeshPrimitiveUtils::GetMorphTangents(const Document& doc, con
     return reader.ReadFloatData(doc, tangentsAccessor);
 }
 
-std::vector<float> MeshPrimitiveUtils::GetTangents(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget)
+std::vector<float> GLTFSDK_API MeshPrimitiveUtils::GetTangents(const Document& doc, const GLTFResourceReader& reader, const MorphTarget& morphTarget)
 {
     const auto& accessor = doc.accessors.Get(morphTarget.tangentsAccessorId);
     return GetMorphTangents(doc, reader, accessor);
 }
 
 // Texcoords
-std::vector<float> MeshPrimitiveUtils::GetTexCoords(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
+std::vector<float> GLTFSDK_API MeshPrimitiveUtils::GetTexCoords(const Document& doc, const GLTFResourceReader& reader, const Accessor& accessor)
 {
     if (accessor.type != TYPE_VEC2)
     {
@@ -707,20 +707,20 @@ std::vector<float> MeshPrimitiveUtils::GetTexCoords(const Document& doc, const G
     return reader.ReadFloatData(doc, accessor);
 }
 
-std::vector<float> MeshPrimitiveUtils::GetTexCoords_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<float> GLTFSDK_API MeshPrimitiveUtils::GetTexCoords_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
     const auto& accessor = doc.accessors.Get(meshPrimitive.GetAttributeAccessorId(ACCESSOR_TEXCOORD_0));
     return GetTexCoords(doc, reader, accessor);
 }
 
-std::vector<float> MeshPrimitiveUtils::GetTexCoords_1(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<float> GLTFSDK_API MeshPrimitiveUtils::GetTexCoords_1(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
     const auto& accessor = doc.accessors.Get(meshPrimitive.GetAttributeAccessorId(ACCESSOR_TEXCOORD_1));
     return GetTexCoords(doc, reader, accessor);
 }
 
 // Colors
-std::vector<uint32_t> MeshPrimitiveUtils::GetColors(const Document& doc, const GLTFResourceReader& reader, const Accessor& colorsAccessor)
+std::vector<uint32_t> GLTFSDK_API MeshPrimitiveUtils::GetColors(const Document& doc, const GLTFResourceReader& reader, const Accessor& colorsAccessor)
 {
     if (colorsAccessor.type != TYPE_VEC4 && colorsAccessor.type != TYPE_VEC3)
     {
@@ -752,14 +752,14 @@ std::vector<uint32_t> MeshPrimitiveUtils::GetColors(const Document& doc, const G
     }
 }
 
-std::vector<uint32_t> MeshPrimitiveUtils::GetColors_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<uint32_t> GLTFSDK_API MeshPrimitiveUtils::GetColors_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
     const auto& accessor = doc.accessors.Get(meshPrimitive.GetAttributeAccessorId(ACCESSOR_COLOR_0));
     return GetColors(doc, reader, accessor);
 }
 
 // Joints
-std::vector<uint32_t> MeshPrimitiveUtils::GetJointIndices32(const Document& doc, const GLTFResourceReader& reader, const Accessor& jointsAccessor)
+std::vector<uint32_t> GLTFSDK_API MeshPrimitiveUtils::GetJointIndices32(const Document& doc, const GLTFResourceReader& reader, const Accessor& jointsAccessor)
 {
     if (jointsAccessor.type != TYPE_VEC4)
     {
@@ -779,13 +779,13 @@ std::vector<uint32_t> MeshPrimitiveUtils::GetJointIndices32(const Document& doc,
     }
 }
 
-std::vector<uint32_t> MeshPrimitiveUtils::GetJointIndices32_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<uint32_t> GLTFSDK_API MeshPrimitiveUtils::GetJointIndices32_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
     const auto& accessor = doc.accessors.Get(meshPrimitive.GetAttributeAccessorId(ACCESSOR_JOINTS_0));
     return GetJointIndices32(doc, reader, accessor);
 }
 
-std::vector<uint64_t> MeshPrimitiveUtils::GetJointIndices64(const Document& doc, const GLTFResourceReader& reader, const Accessor& jointsAccessor)
+std::vector<uint64_t> GLTFSDK_API MeshPrimitiveUtils::GetJointIndices64(const Document& doc, const GLTFResourceReader& reader, const Accessor& jointsAccessor)
 {
     if (jointsAccessor.type != TYPE_VEC4)
     {
@@ -805,14 +805,14 @@ std::vector<uint64_t> MeshPrimitiveUtils::GetJointIndices64(const Document& doc,
     }
 }
 
-std::vector<uint64_t> MeshPrimitiveUtils::GetJointIndices64_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<uint64_t> GLTFSDK_API MeshPrimitiveUtils::GetJointIndices64_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
     const auto& accessor = doc.accessors.Get(meshPrimitive.GetAttributeAccessorId(ACCESSOR_JOINTS_0));
     return GetJointIndices64(doc, reader, accessor);
 }
 
 // Weights
-std::vector<uint32_t> MeshPrimitiveUtils::GetJointWeights32(const Document& doc, const GLTFResourceReader& reader, const Accessor& weightsAccessor)
+std::vector<uint32_t> GLTFSDK_API MeshPrimitiveUtils::GetJointWeights32(const Document& doc, const GLTFResourceReader& reader, const Accessor& weightsAccessor)
 {
     if (weightsAccessor.type != TYPE_VEC4)
     {
@@ -838,48 +838,48 @@ std::vector<uint32_t> MeshPrimitiveUtils::GetJointWeights32(const Document& doc,
     }
 }
 
-std::vector<uint32_t> MeshPrimitiveUtils::GetJointWeights32_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
+std::vector<uint32_t> GLTFSDK_API MeshPrimitiveUtils::GetJointWeights32_0(const Document& doc, const GLTFResourceReader& reader, const MeshPrimitive& meshPrimitive)
 {
     const auto& accessor = doc.accessors.Get(meshPrimitive.GetAttributeAccessorId(ACCESSOR_WEIGHTS_0));
     return GetJointWeights32(doc, reader, accessor);
 }
 
-std::vector<uint16_t> MeshPrimitiveUtils::ReverseTriangulateIndices16(const uint16_t* indices, size_t indexCount, MeshMode mode)
+std::vector<uint16_t> GLTFSDK_API MeshPrimitiveUtils::ReverseTriangulateIndices16(const uint16_t* indices, size_t indexCount, MeshMode mode)
 {
     return ReverseTriangulateIndices(indices, indexCount, mode);
 }
 
-std::vector<uint32_t> MeshPrimitiveUtils::ReverseTriangulateIndices32(const uint32_t* indices, size_t indexCount, MeshMode mode)
+std::vector<uint32_t> GLTFSDK_API MeshPrimitiveUtils::ReverseTriangulateIndices32(const uint32_t* indices, size_t indexCount, MeshMode mode)
 {
     return ReverseTriangulateIndices(indices, indexCount, mode);
 }
 
-std::vector<uint16_t> MeshPrimitiveUtils::ReverseTriangulateIndices16(const std::vector<uint16_t>& indices, MeshMode mode)
+std::vector<uint16_t> GLTFSDK_API MeshPrimitiveUtils::ReverseTriangulateIndices16(const std::vector<uint16_t>& indices, MeshMode mode)
 {
     return ReverseTriangulateIndices(indices.data(), indices.size(), mode);
 }
 
-std::vector<uint32_t> MeshPrimitiveUtils::ReverseTriangulateIndices32(const std::vector<uint32_t>& indices, MeshMode mode)
+std::vector<uint32_t> GLTFSDK_API MeshPrimitiveUtils::ReverseTriangulateIndices32(const std::vector<uint32_t>& indices, MeshMode mode)
 {
     return ReverseTriangulateIndices(indices.data(), indices.size(), mode);
 }
 
-std::vector<uint16_t> MeshPrimitiveUtils::ReverseSegmentIndices16(const uint16_t* indices, size_t indexCount, MeshMode mode)
+std::vector<uint16_t> GLTFSDK_API MeshPrimitiveUtils::ReverseSegmentIndices16(const uint16_t* indices, size_t indexCount, MeshMode mode)
 {
     return ReverseSegmentIndices(indices, indexCount, mode);
 }
 
-std::vector<uint32_t> MeshPrimitiveUtils::ReverseSegmentIndices32(const uint32_t* indices, size_t indexCount, MeshMode mode)
+std::vector<uint32_t> GLTFSDK_API MeshPrimitiveUtils::ReverseSegmentIndices32(const uint32_t* indices, size_t indexCount, MeshMode mode)
 {
     return ReverseSegmentIndices(indices, indexCount, mode);
 }
 
-std::vector<uint16_t> MeshPrimitiveUtils::ReverseSegmentIndices16(const std::vector<uint16_t>& indices, MeshMode mode)
+std::vector<uint16_t> GLTFSDK_API MeshPrimitiveUtils::ReverseSegmentIndices16(const std::vector<uint16_t>& indices, MeshMode mode)
 {
     return ReverseSegmentIndices(indices.data(), indices.size(), mode);
 }
 
-std::vector<uint32_t> MeshPrimitiveUtils::ReverseSegmentIndices32(const std::vector<uint32_t>& indices, MeshMode mode)
+std::vector<uint32_t> GLTFSDK_API MeshPrimitiveUtils::ReverseSegmentIndices32(const std::vector<uint32_t>& indices, MeshMode mode)
 {
     return ReverseSegmentIndices(indices.data(), indices.size(), mode);
 }

--- a/GLTFSDK/Source/PBRUtils.cpp
+++ b/GLTFSDK/Source/PBRUtils.cpp
@@ -6,7 +6,7 @@
 using namespace Microsoft::glTF;
 
 // https://bghgary.github.io/glTF/convert-between-workflows-bjs/js/babylon.pbrUtilities.js
-float Detail::SolveMetallic(float dielectricSpecular, float diffuse, float specular, float oneMinusSpecularStrength)
+float GLTFSDK_API Detail::SolveMetallic(float dielectricSpecular, float diffuse, float specular, float oneMinusSpecularStrength)
 {
     if (specular <= dielectricSpecular)
     {
@@ -41,12 +41,12 @@ namespace Microsoft
     }
 }
 
-MetallicRoughnessValue Microsoft::glTF::SGToMR(const SpecularGlossinessValue& sg)
+MetallicRoughnessValue GLTFSDK_API Microsoft::glTF::SGToMR(const SpecularGlossinessValue& sg)
 {
     return SGToMR<Color3>(sg);
 }
 
-SpecularGlossinessValue Microsoft::glTF::MRToSG(const MetallicRoughnessValue& mr)
+SpecularGlossinessValue GLTFSDK_API Microsoft::glTF::MRToSG(const MetallicRoughnessValue& mr)
 {
     return MRToSG<Color3>(mr);
 }

--- a/GLTFSDK/Source/Schema.cpp
+++ b/GLTFSDK/Source/Schema.cpp
@@ -87,12 +87,12 @@ namespace
 
 // Microsoft::glTF namespace function definitions
 
-const std::unordered_map<std::string, std::string>& Microsoft::glTF::GetDefaultSchemaUriMap()
+const std::unordered_map<std::string, std::string>& GLTFSDK_API Microsoft::glTF::GetDefaultSchemaUriMap()
 {
     return SchemaJson::GLTF_SCHEMA_MAP;
 }
 
-std::unique_ptr<const ISchemaLocator> Microsoft::glTF::GetDefaultSchemaLocator(SchemaFlags schemaFlags)
+std::unique_ptr<const ISchemaLocator> GLTFSDK_API Microsoft::glTF::GetDefaultSchemaLocator(SchemaFlags schemaFlags)
 {
     return std::make_unique<const DefaultSchemaLocator>(schemaFlags);
 }

--- a/GLTFSDK/Source/SchemaValidation.cpp
+++ b/GLTFSDK/Source/SchemaValidation.cpp
@@ -54,7 +54,7 @@ namespace
     };
 }
 
-void Microsoft::glTF::ValidateDocumentAgainstSchema(const rapidjson::Document& document, const std::string& schemaUri, std::unique_ptr<const ISchemaLocator> schemaLocator)
+void GLTFSDK_API Microsoft::glTF::ValidateDocumentAgainstSchema(const rapidjson::Document& document, const std::string& schemaUri, std::unique_ptr<const ISchemaLocator> schemaLocator)
 {
     if (!schemaLocator)
     {

--- a/GLTFSDK/Source/Serialize.cpp
+++ b/GLTFSDK/Source/Serialize.cpp
@@ -864,12 +864,12 @@ namespace
     }
 }
 
-std::string Microsoft::glTF::Serialize(const Document& gltfDocument, SerializeFlags flags)
+std::string GLTFSDK_API Microsoft::glTF::Serialize(const Document& gltfDocument, SerializeFlags flags)
 {
     return Serialize(gltfDocument, ExtensionSerializer(), flags);
 }
 
-std::string Microsoft::glTF::Serialize(const Document& gltfDocument, const ExtensionSerializer& extensionSerializer, SerializeFlags flags)
+std::string GLTFSDK_API Microsoft::glTF::Serialize(const Document& gltfDocument, const ExtensionSerializer& extensionSerializer, SerializeFlags flags)
 {
     auto doc = CreateJsonDocument(gltfDocument, extensionSerializer);
 

--- a/GLTFSDK/Source/Validation.cpp
+++ b/GLTFSDK/Source/Validation.cpp
@@ -151,13 +151,13 @@ namespace
     }
 }
 
-void Validation::Validate(const Document& doc)
+void GLTFSDK_API Validation::Validate(const Document& doc)
 {
     ValidateAccessors(doc);
     ValidateMeshes(doc);
 }
 
-void Validation::ValidateAccessors(const Document& doc)
+void GLTFSDK_API Validation::ValidateAccessors(const Document& doc)
 {
     for (const auto& accessor : doc.accessors.Elements())
     {
@@ -165,7 +165,7 @@ void Validation::ValidateAccessors(const Document& doc)
     }
 }
 
-void Validation::ValidateMeshes(const Document& doc)
+void GLTFSDK_API Validation::ValidateMeshes(const Document& doc)
 {
     for (const auto& mesh : doc.meshes.Elements())
     {
@@ -176,7 +176,7 @@ void Validation::ValidateMeshes(const Document& doc)
     }
 }
 
-void Validation::ValidateMeshPrimitive(const Document& doc, const MeshPrimitive& primitive)
+void GLTFSDK_API Validation::ValidateMeshPrimitive(const Document& doc, const MeshPrimitive& primitive)
 {
     if (!primitive.HasAttribute(ACCESSOR_POSITION))
     {
@@ -200,7 +200,7 @@ void Validation::ValidateMeshPrimitive(const Document& doc, const MeshPrimitive&
     ValidateMeshPrimitiveAttributeAccessors(doc, primitive.attributes, vertexCount);
 }
 
-void Validation::ValidateMeshPrimitiveAttributeAccessors(
+void GLTFSDK_API Validation::ValidateMeshPrimitiveAttributeAccessors(
     const Document& doc,
     const std::unordered_map<std::string, std::string>& attributes,
     const size_t vertexCount
@@ -241,7 +241,7 @@ void Validation::ValidateMeshPrimitiveAttributeAccessors(
     }
 }
 
-void Validation::ValidateAccessorTypes(
+void GLTFSDK_API Validation::ValidateAccessorTypes(
     const Accessor& accessor,
     const std::string& accessorName,
     const std::set<AccessorType>& accessorTypes,
@@ -263,7 +263,7 @@ void Validation::ValidateAccessorTypes(
     }
 }
 
-void Validation::ValidateAccessor(const Document& gltfDocument, const Accessor& accessor)
+void GLTFSDK_API Validation::ValidateAccessor(const Document& gltfDocument, const Accessor& accessor)
 {
     if (!accessor.bufferViewId.empty())
     {
@@ -288,7 +288,7 @@ void Validation::ValidateAccessor(const Document& gltfDocument, const Accessor& 
     }
 }
 
-void Validation::ValidateBufferView(const BufferView& buffer_view, const Buffer& buffer)
+void GLTFSDK_API Validation::ValidateBufferView(const BufferView& buffer_view, const Buffer& buffer)
 {
     size_t totalBufferViewLength;
     if (!SafeAddition(buffer_view.byteOffset, buffer_view.byteLength, totalBufferViewLength))
@@ -307,7 +307,7 @@ void Validation::ValidateBufferView(const BufferView& buffer_view, const Buffer&
 // Figure out if the two arguments, when summed, will overflow a size_t or not.
 // If addition was successful, return true and the result of the addition in result.
 // If addition was unsuccessful, return false and the value in result is not valid.
-bool Validation::SafeAddition(size_t a, size_t b, size_t& result)
+bool GLTFSDK_API Validation::SafeAddition(size_t a, size_t b, size_t& result)
 {
     if (b <= std::numeric_limits<size_t>::max() - a)
     {
@@ -322,7 +322,7 @@ bool Validation::SafeAddition(size_t a, size_t b, size_t& result)
 // Figure out if the two arguments, when multiplied, will overflow a size_t or not.
 // If multiplication was successful, return true and the result of the addition in result.
 // If multiplication was unsuccessful, return false and the value in result is not valid.
-bool Validation::SafeMultiplication(size_t a, size_t b, size_t& result)
+bool GLTFSDK_API Validation::SafeMultiplication(size_t a, size_t b, size_t& result)
 {
     if (b == 0)
     {

--- a/GLTFSDK/Source/Version.cpp
+++ b/GLTFSDK/Source/Version.cpp
@@ -73,7 +73,7 @@ std::tuple<uint32_t, uint32_t> Version::AsTuple(const char* version)
     }
 }
 
-bool Microsoft::glTF::IsMinVersionRequirementSatisfied(const Version& minVersion, std::initializer_list<Version> supported)
+bool GLTFSDK_API Microsoft::glTF::IsMinVersionRequirementSatisfied(const Version& minVersion, std::initializer_list<Version> supported)
 {
     if (supported.size() == 0U)
     {
@@ -100,7 +100,7 @@ bool Microsoft::glTF::IsMinVersionRequirementSatisfied(const Version& minVersion
     return false;
 }
 
-bool Microsoft::glTF::IsMinVersionRequirementSatisfied(const std::string& minVersion, std::initializer_list<Version> supported)
+bool GLTFSDK_API Microsoft::glTF::IsMinVersionRequirementSatisfied(const std::string& minVersion, std::initializer_list<Version> supported)
 {
     if (supported.size() == 0U)
     {


### PR DESCRIPTION
Without explicit calling convention modifers, consumers are required to compile with the same calling convention used in the released binaries. If a consumer compiles with the `__stdcall` calling convention, the linker won't resolve the glTF-SDK calls because the released binaries are built with the default `__cdecl` calling convention.

This change fixes the issue using an overridable `GLTFSDK_API` macro defined as `__cdecl` by default on Windows platforms or defined as empty on non-Windows platforms.