### PR TITLE
Fix build error when Set-StrictMode is enabled.

### DIFF
--- a/GLTFSDK/GenerateSchemaJsonHeader.ps1
+++ b/GLTFSDK/GenerateSchemaJsonHeader.ps1
@@ -225,7 +225,7 @@ Get-ChildItem -File -Recurse -Filter "*.json" "$SCHEMAS_PATH" | Sort-Object | Fo
    AppendToHeader $varText $globalIndentLevel
 }
 
-DeclareGltfSchemaVars $CLASS_NAME
+DeclareGltfSchemaVars
 
 CloseScope "class $CLASS_NAME" $scopeSet
 

--- a/GLTFSDK/GenerateSchemaJsonHeader.ps1
+++ b/GLTFSDK/GenerateSchemaJsonHeader.ps1
@@ -225,7 +225,7 @@ Get-ChildItem -File -Recurse -Filter "*.json" "$SCHEMAS_PATH" | Sort-Object | Fo
    AppendToHeader $varText $globalIndentLevel
 }
 
-DeclareGltfSchemaVars $CLASS_NAME $mapNamesList
+DeclareGltfSchemaVars $CLASS_NAME
 
 CloseScope "class $CLASS_NAME" $scopeSet
 


### PR DESCRIPTION
When Set-StrictMode is enabled, trying to read unset variable will throw the following error.
> GenerateSchemaJsonHeader.ps1: The variable '$mapNamesList' cannot be retrieved because it has not been set.