### PR TITLE
Ability to flush a GLB manifest to a stream

### DIFF
--- a/GLTFSDK/Inc/GLTFSDK/GLBResourceWriter.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLBResourceWriter.h
@@ -20,6 +20,9 @@ namespace Microsoft
             GLBResourceWriter(std::unique_ptr<IStreamWriterCache> streamCache);
             GLBResourceWriter(std::unique_ptr<IStreamWriterCache> streamCache, std::unique_ptr<std::iostream> tempBufferStream);
 
+            // Write to a stream instead of a file (can be useful for draco compression)
+            template <typename T>
+            void FlushStream(const std::string& manifest, T* stream);
             void Flush(const std::string& manifest, const std::string& uri);
             std::string GenerateBufferUri(const std::string& bufferId) const override;
             std::ostream* GetBufferStream(const std::string& bufferId) override;

--- a/GLTFSDK/Inc/GLTFSDK/GLTFResourceWriter.h
+++ b/GLTFSDK/Inc/GLTFSDK/GLTFResourceWriter.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <GLTFSDK/ResourceWriter.h>
+#include <limits>
 
 #include <memory>
 

--- a/GLTFSDK/Inc/GLTFSDK/PBRUtils.h
+++ b/GLTFSDK/Inc/GLTFSDK/PBRUtils.h
@@ -5,6 +5,7 @@
 
 #include <GLTFSDK/Color.h>
 #include <GLTFSDK/ExtensionsKHR.h>
+#include <limits>
 
 namespace Microsoft
 {

--- a/GLTFSDK/Inc/GLTFSDK/ResourceReaderUtils.h
+++ b/GLTFSDK/Inc/GLTFSDK/ResourceReaderUtils.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <cmath>
+#include <limits>
 
 namespace Microsoft
 {

--- a/GLTFSDK/Source/GLBResourceWriter.cpp
+++ b/GLTFSDK/Source/GLBResourceWriter.cpp
@@ -4,6 +4,8 @@
 #include <GLTFSDK/GLBResourceWriter.h>
 
 #include <sstream>
+#include <fstream>
+#include <iostream>
 
 using namespace Microsoft::glTF;
 
@@ -42,7 +44,8 @@ GLBResourceWriter::GLBResourceWriter(std::unique_ptr<IStreamWriterCache> streamC
 {
 }
 
-void GLBResourceWriter::Flush(const std::string& manifest, const std::string& uri)
+template <typename T>
+void GLBResourceWriter::FlushStream(const std::string& manifest, T* stream)
 {
     uint32_t jsonChunkLength = static_cast<uint32_t>(manifest.length());
     const uint32_t jsonPaddingLength = ::CalculatePadding(jsonChunkLength);
@@ -59,7 +62,6 @@ void GLBResourceWriter::Flush(const std::string& manifest, const std::string& ur
         + sizeof(binaryChunkLength) + GLB_CHUNK_TYPE_SIZE // 8 bytes (BIN header)
         + binaryChunkLength;
 
-    auto stream = m_streamWriterCache->Get(uri);
 
     // Write GLB header (12 bytes)
     StreamUtils::WriteBinary(*stream, GLB_HEADER_MAGIC_STRING, GLB_HEADER_MAGIC_STRING_SIZE);
@@ -94,6 +96,12 @@ void GLBResourceWriter::Flush(const std::string& manifest, const std::string& ur
         // GLB spec requires the BIN chunk to be padded with trailing zeros (0x00) to satisfy alignment requirements
         StreamUtils::WriteBinary(*stream, std::vector<uint8_t>(binaryPaddingLength, 0));
     }
+}
+
+void GLBResourceWriter::Flush(const std::string& manifest, const std::string& uri)
+{
+    auto stream = m_streamWriterCache->Get(uri);
+    this->FlushStream<std::ostream>(manifest, stream.get());
 }
 
 std::string GLBResourceWriter::GenerateBufferUri(const std::string& bufferId) const

--- a/GLTFSDK/Source/GLBResourceWriter.cpp
+++ b/GLTFSDK/Source/GLBResourceWriter.cpp
@@ -5,7 +5,6 @@
 
 #include <sstream>
 #include <fstream>
-#include <iostream>
 
 using namespace Microsoft::glTF;
 
@@ -97,6 +96,9 @@ void GLBResourceWriter::FlushStream(const std::string& manifest, T* stream)
         StreamUtils::WriteBinary(*stream, std::vector<uint8_t>(binaryPaddingLength, 0));
     }
 }
+
+template void GLBResourceWriter::FlushStream<std::fstream>(const std::string& manifest, std::fstream* stream);
+template void GLBResourceWriter::FlushStream<std::stringstream>(const std::string& manifest, std::stringstream* stream);
 
 void GLBResourceWriter::Flush(const std::string& manifest, const std::string& uri)
 {

--- a/GLTFSDK/Source/Validation.cpp
+++ b/GLTFSDK/Source/Validation.cpp
@@ -7,6 +7,8 @@
 
 #include <sstream>
 
+#include <limits>
+
 using namespace Microsoft::glTF;
 
 namespace

--- a/GLTFSDK/Source/Version.cpp
+++ b/GLTFSDK/Source/Version.cpp
@@ -8,6 +8,7 @@
 #include <set>
 #include <regex>
 #include <sstream>
+#include <limits>
 
 using namespace Microsoft::glTF;
 


### PR DESCRIPTION
# Description
This pull request introduces a new feature that allows the library to flush a GLB manifest to a specified output stream. The change enhances the library's flexibility by supporting different stream types.

# Code Highlights
The main modification involves updating the `GLBResourceWriter` class to support flushing the GLB manifest to an output stream. The updated code snippet is as follows:

```
if (auto glbResourceWriter = dynamic_cast<GLBResourceWriter*>(&gltfResourceWriter))
{
    // The GLB container is created when the GLBResourceWriter::Flush member function is invoked
    glbResourceWriter->FlushStream<T>(manifest, stream);
}
```
In this implementation `T` can be either a `std::fstream` or a `std::stringstream`, providing flexibility in how the GLB manifest data is handled.

# Benefits
- ***Customizable Output Handling***: By allowing different stream types, users can now easily redirect the output to various destinations.
- ***Enhanced Data Manipulation***: This functionality is particularly useful for scenarios where further processing is required, such as applying Draco compression or other transformations to the GLB data before it is finalized.