### PR TITLE
Add MSVC security flags back in

### DIFF
--- a/GLTFSDK/CMakeLists.txt
+++ b/GLTFSDK/CMakeLists.txt
@@ -44,6 +44,8 @@ if (MSVC)
     # Set warning level to 4 (/W4)
     target_compile_options(GLTFSDK PRIVATE "/Zi;/W4;/EHsc")
 
+    add_msvc_security_flags(GLTFSDK)
+
     # Make sure that all PDB files on Windows are installed to the output folder with the libraries. By default, only the debug build does this.
     set_target_properties(GLTFSDK PROPERTIES COMPILE_PDB_NAME "GLTFSDK" COMPILE_PDB_OUTPUT_DIRECTORY "${LIBRARY_OUTPUT_DIRECTORY}")
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
The MSVC security compiler flags were removed in [PR 141](https://github.com/microsoft/glTF-SDK/pull/141). This change adds them back.