### PR TITLE
Apply security compiler flags to sample and test targets

### DIFF
--- a/GLTFSDK.Samples/Deserialize/CMakeLists.txt
+++ b/GLTFSDK.Samples/Deserialize/CMakeLists.txt
@@ -15,6 +15,8 @@ if (MSVC)
     # Set warning level to 4 (/W4)
     target_compile_options(Deserialize PRIVATE "/Zi;/W4;/EHsc")
 
+    add_msvc_security_flags(Deserialize)
+
     # Make sure that all PDB files on Windows are installed to the output folder.  By default, only the debug build does this.
     set_target_properties(Deserialize PROPERTIES COMPILE_PDB_NAME "Deserialize" COMPILE_PDB_OUTPUT_DIRECTORY "${RUNTIME_OUTPUT_DIRECTORY}")
 endif()

--- a/GLTFSDK.Samples/Serialize/CMakeLists.txt
+++ b/GLTFSDK.Samples/Serialize/CMakeLists.txt
@@ -15,6 +15,8 @@ if (MSVC)
     # Set warning level to 4 (/W4)
     target_compile_options(Serialize PRIVATE "/Zi;/W4;/EHsc")
 
+    add_msvc_security_flags(Serialize)
+
     # Make sure that all PDB files on Windows are installed to the output folder.  By default, only the debug build does this.
     set_target_properties(Serialize PROPERTIES COMPILE_PDB_NAME "Serialize" COMPILE_PDB_OUTPUT_DIRECTORY "${RUNTIME_OUTPUT_DIRECTORY}")
 endif()

--- a/GLTFSDK.Test/CMakeLists.txt
+++ b/GLTFSDK.Test/CMakeLists.txt
@@ -16,6 +16,8 @@ if (MSVC)
     # Set warning level to 4 (/W4)
     target_compile_options(GLTFSDK.Test PRIVATE "/Zi;/W4;/EHsc")
 
+    add_msvc_security_flags(GLTFSDK.Test)
+
     # Make sure that all PDB files on Windows are installed to the output folder.  By default, only the debug build does this.
     set_target_properties(GLTFSDK.Test PROPERTIES COMPILE_PDB_NAME "GLTFSDK.Test" COMPILE_PDB_OUTPUT_DIRECTORY "${RUNTIME_OUTPUT_DIRECTORY}")
 endif()


### PR DESCRIPTION
The library built by this project has the security compiler flags set for MSVC, but the sample and test targets do not. This change applies the security compiler flags to the sample and test targets, too.