### PR TITLE
Check for valid extension objects

### DIFF
--- a/GLTFSDK/Source/ExtensionsKHR.cpp
+++ b/GLTFSDK/Source/ExtensionsKHR.cpp
@@ -234,6 +234,9 @@ std::unique_ptr<Extension> KHR::Materials::DeserializePBRSpecGloss(const std::st
     Materials::PBRSpecularGlossiness specGloss;
 
     auto doc = RapidJsonUtils::CreateDocumentFromString(json);
+    if (!doc.IsObject()) {
+      return std::make_unique<Materials::PBRSpecularGlossiness>(specGloss);
+    }
     const auto sit = doc.GetObject();
 
     // Diffuse Factor
@@ -314,6 +317,9 @@ std::unique_ptr<Extension> KHR::Materials::DeserializeUnlit(const std::string& j
     Unlit unlit;
 
     auto doc = RapidJsonUtils::CreateDocumentFromString(json);
+    if (!doc.IsObject()) {
+      return std::make_unique<Unlit>(unlit);
+    }
     const auto objValue = doc.GetObject();
 
     ParseProperty(objValue, unlit, extensionDeserializer);
@@ -375,6 +381,9 @@ std::unique_ptr<Extension> KHR::MeshPrimitives::DeserializeDracoMeshCompression(
     auto extension = std::make_unique<DracoMeshCompression>();
 
     auto doc = RapidJsonUtils::CreateDocumentFromString(json);
+    if (!doc.IsObject()) {
+      return extension;
+    }
     const auto v = doc.GetObject();
 
     extension->bufferViewId = GetMemberValueAsString<uint32_t>(v, "bufferView");
@@ -481,6 +490,9 @@ std::unique_ptr<Extension> KHR::TextureInfos::DeserializeTextureTransform(const 
     TextureTransform textureTransform;
 
     auto doc = RapidJsonUtils::CreateDocumentFromString(json);
+    if (!doc.IsObject()) {
+      return std::make_unique<TextureTransform>(textureTransform);
+    }
     const auto sit = doc.GetObject();
 
     // Offset


### PR DESCRIPTION
We ran into issues with user glTF files with a badly formed KHR_texture_transform extension.
```
"KHR_texture_transform": "not an object"
```

The deserialize function fails with an access violation because it assumes that the extension is an object.

For the record, these bad glTF's have a generator of `COLLADA2GLTF`
