### PR TITLE
Fix for Draco attribute deserialization

### DIFF
--- a/GLTFSDK/Source/ExtensionsKHR.cpp
+++ b/GLTFSDK/Source/ExtensionsKHR.cpp
@@ -237,7 +237,7 @@ std::unique_ptr<Extension> KHR::Materials::DeserializePBRSpecGloss(const std::st
     if (!doc.IsObject()) {
       return std::make_unique<Materials::PBRSpecularGlossiness>(specGloss);
     }
-    const rapidjson::Value sit = doc.GetObject();
+    const rapidjson::Value& sit = doc;
 
     // Diffuse Factor
     auto diffuseFactIt = sit.FindMember("diffuseFactor");
@@ -320,7 +320,7 @@ std::unique_ptr<Extension> KHR::Materials::DeserializeUnlit(const std::string& j
     if (!doc.IsObject()) {
       return std::make_unique<Unlit>(unlit);
     }
-    const rapidjson::Value objValue = doc.GetObject();
+    const rapidjson::Value& objValue = doc;
 
     ParseProperty(objValue, unlit, extensionDeserializer);
 
@@ -384,7 +384,7 @@ std::unique_ptr<Extension> KHR::MeshPrimitives::DeserializeDracoMeshCompression(
     if (!doc.IsObject()) {
       return extension;
     }
-    const rapidjson::Value v = doc.GetObject();
+    const rapidjson::Value& v = doc;
 
     extension->bufferViewId = GetMemberValueAsString<uint32_t>(v, "bufferView");
 
@@ -493,7 +493,7 @@ std::unique_ptr<Extension> KHR::TextureInfos::DeserializeTextureTransform(const 
     if (!doc.IsObject()) {
       return std::make_unique<TextureTransform>(textureTransform);
     }
-    const rapidjson::Value sit = doc.GetObject();
+    const rapidjson::Value& sit = doc;
 
     // Offset
     auto offsetIt = sit.FindMember("offset");

--- a/GLTFSDK/Source/ExtensionsKHR.cpp
+++ b/GLTFSDK/Source/ExtensionsKHR.cpp
@@ -237,7 +237,7 @@ std::unique_ptr<Extension> KHR::Materials::DeserializePBRSpecGloss(const std::st
     if (!doc.IsObject()) {
       return std::make_unique<Materials::PBRSpecularGlossiness>(specGloss);
     }
-    const auto sit = doc.GetObject();
+    const rapidjson::Value sit = doc.GetObject();
 
     // Diffuse Factor
     auto diffuseFactIt = sit.FindMember("diffuseFactor");
@@ -320,7 +320,7 @@ std::unique_ptr<Extension> KHR::Materials::DeserializeUnlit(const std::string& j
     if (!doc.IsObject()) {
       return std::make_unique<Unlit>(unlit);
     }
-    const auto objValue = doc.GetObject();
+    const rapidjson::Value objValue = doc.GetObject();
 
     ParseProperty(objValue, unlit, extensionDeserializer);
 
@@ -493,7 +493,7 @@ std::unique_ptr<Extension> KHR::TextureInfos::DeserializeTextureTransform(const 
     if (!doc.IsObject()) {
       return std::make_unique<TextureTransform>(textureTransform);
     }
-    const auto sit = doc.GetObject();
+    const rapidjson::Value sit = doc.GetObject();
 
     // Offset
     auto offsetIt = sit.FindMember("offset");

--- a/GLTFSDK/Source/ExtensionsKHR.cpp
+++ b/GLTFSDK/Source/ExtensionsKHR.cpp
@@ -384,7 +384,7 @@ std::unique_ptr<Extension> KHR::MeshPrimitives::DeserializeDracoMeshCompression(
     if (!doc.IsObject()) {
       return extension;
     }
-    const auto v = doc.GetObject();
+    const rapidjson::Value v = doc.GetObject();
 
     extension->bufferViewId = GetMemberValueAsString<uint32_t>(v, "bufferView");
 


### PR DESCRIPTION
After updating to the latest glTF SDK, I'm finding that deserialization of Draco attributes no longer works.
`v.FindMember("attributes");` fails to find the attributes object and so no skinning information can be imported (e.g. joints and weights).
I've traced this down to the `const auto v = doc.GetObject();` call.
Changing it to `const rapidjson::Value v = doc.GetObject();` fixes the issue entirely.

This [commit](https://github.com/microsoft/glTF-SDK/commit/eaccf166e2718c6133db426545b6d008cb7ad79f) is what started this issue. Do we know the reason for changing to using `auto`?