### PR TITLE
Fix SchemaDocument being called with the wrong number of arguments.

### DIFF
--- a/GLTFSDK/Source/SchemaValidation.cpp
+++ b/GLTFSDK/Source/SchemaValidation.cpp
@@ -34,7 +34,7 @@ namespace
                 throw GLTFException("Schema document at " + uri + " is not valid JSON");
             }
 
-            auto result = schemaDocuments.emplace(uri, rapidjson::SchemaDocument(document, nullptr, 0, this));
+            auto result = schemaDocuments.emplace(uri, rapidjson::SchemaDocument(document, this));
             assert(result.second);
             auto resultSchemaDoc = &(result.first->second);
             assert(resultSchemaDoc);


### PR DESCRIPTION
Fixes #121

Mirroring my comment on the issue here for visibility.

The current code doesn't compile because of bad arguments. There is no 4 parameter constructor for SchemaDocument and there never was one in previous rapidjson versions either. Looking at 9428f11, where this issue was introduced, it seems like someone tried to change the call from SchemaDocument(document, this) to SchemaDocument(document, nullptr, 0) when the rapidjson version was bumped but forgot to remove the "this". That would at least be syntactically correct but still logically false and results in test failures.