### PR TITLE
Update CMake min req for gtest

### DIFF
--- a/External/googletest/CMakeGoogleTestDownload.txt.in
+++ b/External/googletest/CMakeGoogleTestDownload.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
Change min required CMake version to match top level CMakeLists

When the gtest version was bumped in dd3e782 the minimum required CMake version wasn't adjusted which currently blocks CMake 4.0 compatibility since <3.10 backcompat was dropped in 4+. 
This change bumps up the min cmake version requirement for the gtest dependency to match the requirement of the top level CMakeLists of the SDK. 