### PR TITLE
Fix mismatched ostream

### DIFF
--- a/GLTFSDK.TestUtils/TestUtilsCommon/UnitTestBridge.h
+++ b/GLTFSDK.TestUtils/TestUtilsCommon/UnitTestBridge.h
@@ -351,7 +351,7 @@ namespace glTF
         {
             inline void WriteMessage(wchar_t const* message)
             {
-                std::cout << message << '\n';
+                std::wcout << message << '\n';
             }
 
             inline void WriteMessage(char const* message)


### PR DESCRIPTION
Correctly matches wchar_t* with wcout in Logger.