### PR TITLE
Update Windows CI and samples to Visual Studio 2026

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     build-windows:
       uses: ./.github/workflows/windows.yml
       with:
-        cmake-version: '3.31.0'
+        cmake-version: '4.2.7'
         platforms: "['x64', 'Win32', 'ARM64']"
         configurations: "['RelWithDebInfo', 'Debug']"
     # MacOS

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,6 +16,11 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    env:
+      # CMake 4.x removed compatibility with cmake_minimum_required(VERSION < 3.5).
+      # The vendored RapidJSON source (downloaded at configure time) still declares an
+      # older minimum, so clamp the policy version for its nested/child configures.
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
     strategy:
         matrix:
             platform: ${{ fromJson(inputs.platforms) }}
@@ -26,11 +31,11 @@ jobs:
         with:
             submodules: 'true'
       - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v2.0.2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
             cmake-version: ${{ inputs.cmake-version }}
       - name: CMake Configure
-        run: cmake -G "Visual Studio 17 2022" -A ${{ matrix.platform }} -B ./Built/Int/cmake_${{ matrix.platform }} .
+        run: cmake -G "Visual Studio 18 2026" -A ${{ matrix.platform }} -B ./Built/Int/cmake_${{ matrix.platform }} .
       - name: CMake Build
         run: cmake --build . --target install --config ${{ matrix.config }}
         working-directory: ./Built/Int/cmake_${{ matrix.platform }}

--- a/External/RapidJSON/CMakeRapidJSONDownload.txt.in
+++ b/External/RapidJSON/CMakeRapidJSONDownload.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(RapidJSON-download NONE)
 

--- a/GLTFSDK.Samples/CMakeLists.txt
+++ b/GLTFSDK.Samples/CMakeLists.txt
@@ -1,4 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
 
+# Visual Studio 2026 (MSVC 14.5x) removed the <experimental/filesystem> header that
+# these samples fall back to under C++14. Build the samples as C++17 so they use the
+# standard <filesystem> header instead (see each sample's Source/main.cpp). The GLTFSDK
+# library itself continues to target C++14.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_subdirectory(Deserialize)
 add_subdirectory(Serialize)


### PR DESCRIPTION
## Summary

The Windows CI is currently broken: GitHub's Windows runners no longer include
Visual Studio 2022, so the `Visual Studio 17 2022` CMake generator fails to
configure with:


CMake Error at CMakeLists.txt:2 (project): Generator "Visual Studio 17 2022" could not find any instance of Visual Studio.


This moves the Windows build to **Visual Studio 2026**.

## Changes

- **`.github/workflows/windows.yml`**
  - Use the `Visual Studio 18 2026` CMake generator (added in CMake 4.2).
  - Bump `jwlawson/actions-setup-cmake` to `v2.2.0`.
  - Set `CMAKE_POLICY_VERSION_MINIMUM=3.5` for the Windows job (see Notes).
- **`.github/workflows/ci.yml`**: pin the Windows CMake version to `4.2.7`
  (macOS / iOS / Linux stay on `3.31.0`).
- **`External/RapidJSON/CMakeRapidJSONDownload.txt.in`**: bump
  `cmake_minimum_required` to `3.5`.
- **`GLTFSDK.Samples/CMakeLists.txt`**: build the samples as C++17.

## Notes

- **CMake 4.x policy floor** — CMake 4.0 removed compatibility with
  `cmake_minimum_required(VERSION < 3.5)`. The vendored RapidJSON source
  (downloaded at configure time) still declares an older minimum, so the Windows
  job sets `CMAKE_POLICY_VERSION_MINIMUM=3.5`, which is inherited by the nested
  configure steps.
- **`<experimental/filesystem>` removal** — the VS 2026 MSVC toolset removed
  `<experimental/filesystem>`, which the samples fell back to under C++14. The
  samples now compile as C++17 and use the standard `<filesystem>` header. The
  GLTFSDK library itself continues to target C++14.

## Validation

Built locally with Visual Studio 2026 + CMake 4.2.7 for **x64** and **Win32** in
both **RelWithDebInfo** and **Debug**; all 345 unit tests pass in every
configuration. ARM64 uses the identical configuration (build-only in CI).
