### PR TITLE
Update Windows CI and samples to Visual Studio 2026

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     build-windows:
       uses: ./.github/workflows/windows.yml
       with:
-        cmake-version: '3.31.0'
+        cmake-version: '4.2.7'
         platforms: "['x64', 'Win32', 'ARM64']"
         configurations: "['RelWithDebInfo', 'Debug']"
     # MacOS

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,6 +16,11 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    env:
+      # CMake 4.x removed compatibility with cmake_minimum_required(VERSION < 3.5).
+      # The vendored RapidJSON source (downloaded at configure time) still declares an
+      # older minimum, so clamp the policy version for its nested/child configures.
+      CMAKE_POLICY_VERSION_MINIMUM: "3.5"
     strategy:
         matrix:
             platform: ${{ fromJson(inputs.platforms) }}
@@ -26,11 +31,11 @@ jobs:
         with:
             submodules: 'true'
       - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v2.0.2
+        uses: jwlawson/actions-setup-cmake@v2.2.0
         with:
             cmake-version: ${{ inputs.cmake-version }}
       - name: CMake Configure
-        run: cmake -G "Visual Studio 17 2022" -A ${{ matrix.platform }} -B ./Built/Int/cmake_${{ matrix.platform }} .
+        run: cmake -G "Visual Studio 18 2026" -A ${{ matrix.platform }} -B ./Built/Int/cmake_${{ matrix.platform }} .
       - name: CMake Build
         run: cmake --build . --target install --config ${{ matrix.config }}
         working-directory: ./Built/Int/cmake_${{ matrix.platform }}

--- a/External/RapidJSON/CMakeRapidJSONDownload.txt.in
+++ b/External/RapidJSON/CMakeRapidJSONDownload.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(RapidJSON-download NONE)
 

--- a/External/googletest/CMakeGoogleTestDownload.txt.in
+++ b/External/googletest/CMakeGoogleTestDownload.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.5)
 
 project(googletest-download NONE)
 

--- a/GLTFSDK.Samples/CMakeLists.txt
+++ b/GLTFSDK.Samples/CMakeLists.txt
@@ -1,4 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
 
+# Visual Studio 2026 (MSVC 14.5x) removed the <experimental/filesystem> header that
+# these samples previously used. Build the samples as C++17 so they use the standard
+# <filesystem> header instead (see each sample's Source/main.cpp). The GLTFSDK library
+# itself continues to target C++14.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_subdirectory(Deserialize)
 add_subdirectory(Serialize)

--- a/GLTFSDK.Samples/Deserialize/Source/main.cpp
+++ b/GLTFSDK.Samples/Deserialize/Source/main.cpp
@@ -6,9 +6,7 @@
 #include <GLTFSDK/GLBResourceReader.h>
 #include <GLTFSDK/Deserialize.h>
 
-// Replace this with <filesystem> (and use std::filesystem rather than
-// std::experimental::filesystem) if your toolchain fully supports C++17
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include <fstream>
 #include <sstream>
@@ -28,7 +26,7 @@ namespace
     class StreamReader : public IStreamReader
     {
     public:
-        StreamReader(std::experimental::filesystem::path pathBase) : m_pathBase(std::move(pathBase))
+        StreamReader(std::filesystem::path pathBase) : m_pathBase(std::move(pathBase))
         {
             assert(m_pathBase.has_root_path());
         }
@@ -44,7 +42,7 @@ namespace
             //    if appropriate.
             // 3. Always open the file stream in binary mode. The glTF SDK will handle any text
             //    encoding issues for us.
-            auto streamPath = m_pathBase / std::experimental::filesystem::u8path(filename);
+            auto streamPath = m_pathBase / std::filesystem::u8path(filename);
             auto stream = std::make_shared<std::ifstream>(streamPath, std::ios_base::binary);
 
             // Check if the stream has no errors and is ready for I/O operations
@@ -57,7 +55,7 @@ namespace
         }
 
     private:
-        std::experimental::filesystem::path m_pathBase;
+        std::filesystem::path m_pathBase;
     };
 
     // Uses the Document class to print some basic information about various top-level glTF entities
@@ -185,13 +183,13 @@ namespace
         }
     }
 
-    void PrintInfo(const std::experimental::filesystem::path& path)
+    void PrintInfo(const std::filesystem::path& path)
     {
         // Pass the absolute path, without the filename, to the stream reader
         auto streamReader = std::make_unique<StreamReader>(path.parent_path());
 
-        std::experimental::filesystem::path pathFile = path.filename();
-        std::experimental::filesystem::path pathFileExt = pathFile.extension();
+        std::filesystem::path pathFile = path.filename();
+        std::filesystem::path pathFileExt = pathFile.extension();
 
         std::string manifest;
 
@@ -271,11 +269,11 @@ int main(int argc, char* argv[])
             throw std::runtime_error("Unexpected number of command line arguments");
         }
 
-        std::experimental::filesystem::path path = argv[1U];
+        std::filesystem::path path = argv[1U];
 
         if (path.is_relative())
         {
-            auto pathCurrent = std::experimental::filesystem::current_path();
+            auto pathCurrent = std::filesystem::current_path();
 
             // Convert the relative path into an absolute path by appending the command line argument to the current path
             pathCurrent /= path;

--- a/GLTFSDK.Samples/Serialize/Source/main.cpp
+++ b/GLTFSDK.Samples/Serialize/Source/main.cpp
@@ -8,9 +8,7 @@
 #include <GLTFSDK/IStreamWriter.h>
 #include <GLTFSDK/Serialize.h>
 
-// Replace this with <filesystem> (and use std::filesystem rather than
-// std::experimental::filesystem) if your toolchain fully supports C++17
-#include <experimental/filesystem>
+#include <filesystem>
 
 #include <fstream>
 #include <sstream>
@@ -30,7 +28,7 @@ namespace
     class StreamWriter : public IStreamWriter
     {
     public:
-        StreamWriter(std::experimental::filesystem::path pathBase) : m_pathBase(std::move(pathBase))
+        StreamWriter(std::filesystem::path pathBase) : m_pathBase(std::move(pathBase))
         {
             assert(m_pathBase.has_root_path());
         }
@@ -46,7 +44,7 @@ namespace
             //    if appropriate.
             // 3. Always open the file stream in binary mode. The glTF SDK will handle any text
             //    encoding issues for us.
-            auto streamPath = m_pathBase / std::experimental::filesystem::u8path(filename);
+            auto streamPath = m_pathBase / std::filesystem::u8path(filename);
             auto stream = std::make_shared<std::ofstream>(streamPath, std::ios_base::binary);
 
             // Check if the stream has no errors and is ready for I/O operations
@@ -59,7 +57,7 @@ namespace
         }
 
     private:
-        std::experimental::filesystem::path m_pathBase;
+        std::filesystem::path m_pathBase;
     };
 
     void CreateTriangleResources(Document& document, BufferBuilder& bufferBuilder, std::string& accessorIdIndices, std::string& accessorIdPositions)
@@ -171,13 +169,13 @@ namespace
         document.SetDefaultScene(std::move(scene), AppendIdPolicy::GenerateOnEmpty);
     }
 
-    void SerializeTriangle(const std::experimental::filesystem::path& path)
+    void SerializeTriangle(const std::filesystem::path& path)
     {
         // Pass the absolute path, without the filename, to the stream writer
         auto streamWriter = std::make_unique<StreamWriter>(path.parent_path());
 
-        std::experimental::filesystem::path pathFile = path.filename();
-        std::experimental::filesystem::path pathFileExt = pathFile.extension();
+        std::filesystem::path pathFile = path.filename();
+        std::filesystem::path pathFileExt = pathFile.extension();
 
         auto MakePathExt = [](const std::string& ext)
         {
@@ -261,11 +259,11 @@ int main(int argc, char* argv[])
             throw std::runtime_error("Unexpected number of command line arguments");
         }
 
-        std::experimental::filesystem::path path = argv[1U];
+        std::filesystem::path path = argv[1U];
 
         if (path.is_relative())
         {
-            auto pathCurrent = std::experimental::filesystem::current_path();
+            auto pathCurrent = std::filesystem::current_path();
 
             // Convert the relative path into an absolute path by appending the command line argument to the current path
             pathCurrent /= path;


### PR DESCRIPTION
## Summary

The Windows CI is currently broken: GitHub's Windows runners no longer include
Visual Studio 2022, so the `Visual Studio 17 2022` CMake generator fails to
configure with:


CMake Error at CMakeLists.txt:2 (project): Generator "Visual Studio 17 2022" could not find any instance of Visual Studio.


This moves the Windows build to **Visual Studio 2026** (backport of the same
change targeting `master`).

## Changes

- **`.github/workflows/windows.yml`**
  - Use the `Visual Studio 18 2026` CMake generator (added in CMake 4.2).
  - Bump `jwlawson/actions-setup-cmake` to `v2.2.0`.
  - Set `CMAKE_POLICY_VERSION_MINIMUM=3.5` for the Windows job (see Notes).
- **`.github/workflows/ci.yml`**: pin the Windows CMake version to `4.2.7`
  (macOS / iOS / Linux stay on `3.31.0`).
- **`External/RapidJSON/CMakeRapidJSONDownload.txt.in`** and
  **`External/googletest/CMakeGoogleTestDownload.txt.in`**: bump
  `cmake_minimum_required` to `3.5`.
- **`GLTFSDK.Samples/CMakeLists.txt`**: build the samples as C++17.
- **`GLTFSDK.Samples/{Serialize,Deserialize}/Source/main.cpp`**: use the standard
  `<filesystem>` header and `std::filesystem` instead of
  `<experimental/filesystem>`.

## Notes

- **CMake 4.x policy floor** — CMake 4.0 removed compatibility with
  `cmake_minimum_required(VERSION < 3.5)`. The vendored RapidJSON source
  (downloaded at configure time) still declares an older minimum, so the Windows
  job sets `CMAKE_POLICY_VERSION_MINIMUM=3.5`, which is inherited by the nested
  configure steps. The RapidJSON and googletest download drivers' own minimums
  are also bumped to `3.5`.
- **`<experimental/filesystem>` removal** — the VS 2026 MSVC toolset removed
  `<experimental/filesystem>`, which the samples used. The samples now compile as
  C++17 and use the standard `<filesystem>` header. The GLTFSDK library itself
  continues to target C++14.

## Validation

Built locally with Visual Studio 2026 + CMake 4.2.7 for **x64** and **Win32** in
both **RelWithDebInfo** and **Debug**; all 389 unit tests pass in every
configuration. ARM64 uses the identical configuration (build-only in CI).