### PR TITLE
Harden GLB header and material factor parsing against malformed input

### DIFF
--- a/GLTFSDK.Test/Source/DeserializeTests.cpp
+++ b/GLTFSDK.Test/Source/DeserializeTests.cpp
@@ -638,6 +638,37 @@ namespace Microsoft
                     });
                 }
 
+                GLTFSDK_TEST_METHOD(DeserializeTests, DeserializeFail_BaseColorFactorTooFewElements)
+                {
+                    // A baseColorFactor array shorter than 4 elements was previously read past the parsed
+                    // elements when schema validation was disabled. The core parser must reject it regardless
+                    // of schema flags.
+                    const char* json = R"({
+    "asset": { "version": "2.0" },
+    "materials": [ { "pbrMetallicRoughness": { "baseColorFactor": [ 0.5 ] } } ]
+})";
+
+                    Assert::ExpectException<GLTFException>([&json]()
+                    {
+                        Deserialize(json, DeserializeFlags::None, SchemaFlags::DisableSchemaRoot);
+                    });
+                }
+
+                GLTFSDK_TEST_METHOD(DeserializeTests, DeserializeFail_EmissiveFactorTooFewElements)
+                {
+                    // An emissiveFactor array shorter than 3 elements was previously read past the parsed
+                    // elements when schema validation was disabled.
+                    const char* json = R"({
+    "asset": { "version": "2.0" },
+    "materials": [ { "emissiveFactor": [ 0.5 ] } ]
+})";
+
+                    Assert::ExpectException<GLTFException>([&json]()
+                    {
+                        Deserialize(json, DeserializeFlags::None, SchemaFlags::DisableSchemaRoot);
+                    });
+                }
+
                 GLTFSDK_TEST_METHOD(DeserializeTests, DeserializeFail_NegativeBufferLength)
                 {
                     Assert::ExpectException<ValidationException>([]()

--- a/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
+++ b/GLTFSDK.Test/Source/GLBResourceWriterTests.cpp
@@ -3,10 +3,13 @@
 
 #include "stdafx.h"
 #include <GLTFSDK/Deserialize.h>
+#include <GLTFSDK/Exceptions.h>
 #include <GLTFSDK/GLBResourceReader.h>
 #include <GLTFSDK/GLBResourceWriter.h>
 #include <GLTFSDK/Serialize.h>
 #include "TestUtils.h"
+
+#include <sstream>
 
 using namespace glTF::UnitTest;
 
@@ -36,6 +39,39 @@ namespace Microsoft
 
                     Assert::IsFalse(stream->fail());
                     Assert::IsTrue(doc == roundTrippedDoc);
+                }
+
+                GLTFSDK_TEST_METHOD(GLBResourceWriterTests, GLBReader_RejectsOverflowingJsonChunkLength)
+                {
+                    // A GLB whose JSON chunk length is 0xFFFFFFFF previously passed the header-size check in
+                    // GLBResourceReader::Init because (GLB_HEADER_BYTE_SIZE + jsonChunkLength) was computed in
+                    // 32-bit and wrapped below the file length. The addition is now performed in 64-bit, so the
+                    // invalid chunk length is rejected.
+                    const std::string json = "{\"asset\":{\"version\":\"2.0\"}}";
+
+                    auto writeU32 = [](std::string& s, uint32_t v)
+                    {
+                        s.push_back(static_cast<char>(v & 0xFF));
+                        s.push_back(static_cast<char>((v >> 8) & 0xFF));
+                        s.push_back(static_cast<char>((v >> 16) & 0xFF));
+                        s.push_back(static_cast<char>((v >> 24) & 0xFF));
+                    };
+
+                    std::string glb;
+                    glb += "glTF";                                                    // magic
+                    writeU32(glb, 2);                                                  // version
+                    writeU32(glb, static_cast<uint32_t>(20 + json.size()));           // total length (matches actual stream length)
+                    writeU32(glb, 0xFFFFFFFFu);                                        // JSON chunk length (overflowing)
+                    glb += "JSON";                                                    // JSON chunk type
+                    glb += json;                                                      // JSON payload
+
+                    auto streamReader = std::make_shared<const StreamReaderWriter>();
+                    auto glbStream = std::make_shared<std::stringstream>(glb, std::ios::in | std::ios::out | std::ios::binary);
+
+                    Assert::ExpectException<InvalidGLTFException>([&streamReader, &glbStream]()
+                    {
+                        GLBResourceReader resourceReader(streamReader, glbStream);
+                    });
                 }
             };
         }

--- a/GLTFSDK/Source/Deserialize.cpp
+++ b/GLTFSDK/Source/Deserialize.cpp
@@ -736,6 +736,10 @@ namespace
                 {
                     baseColorFactor.push_back(static_cast<float>(ait->GetDouble()));
                 }
+                if (baseColorFactor.size() != 4)
+                {
+                    throw InvalidGLTFException("baseColorFactor must be an array of 4 numeric elements");
+                }
                 material.metallicRoughness.baseColorFactor = Color4(baseColorFactor[0], baseColorFactor[1], baseColorFactor[2], baseColorFactor[3]);
             }
             
@@ -786,6 +790,10 @@ namespace
             for (rapidjson::Value::ConstValueIterator ait = emissionFactorIt->value.Begin(); ait != emissionFactorIt->value.End(); ++ait)
             {
                 emissiveFactor.push_back(static_cast<float>(ait->GetDouble()));
+            }
+            if (emissiveFactor.size() != 3)
+            {
+                throw InvalidGLTFException("emissiveFactor must be an array of 3 numeric elements");
             }
             material.emissiveFactor = Color3(emissiveFactor[0], emissiveFactor[1], emissiveFactor[2]);
         }

--- a/GLTFSDK/Source/GLBResourceReader.cpp
+++ b/GLTFSDK/Source/GLBResourceReader.cpp
@@ -138,8 +138,9 @@ void GLBResourceReader::Init()
         throw InvalidGLTFException("Unsupported GLB Version: " + std::to_string(version));
     }
 
-    // Length has been validated as the actual length of the file, but make sure to include the header bytes in this check
-    if (length < (GLB_HEADER_BYTE_SIZE + jsonChunkLength))
+    // Perform the addition in 64-bit so it cannot wrap for large 32-bit chunk lengths: a wrapped sum could be
+    // smaller than the file length and pass this check incorrectly.
+    if (length < (static_cast<uint64_t>(GLB_HEADER_BYTE_SIZE) + jsonChunkLength))
     {
         throw InvalidGLTFException("File length " + std::to_string(length) + " less than content length " + std::to_string(jsonChunkLength) + 
             " plus header length " + std::to_string(GLB_HEADER_BYTE_SIZE));
@@ -148,7 +149,7 @@ void GLBResourceReader::Init()
     m_json = ReadJson(*m_buffer, jsonChunkLength);
 
     // If length is exactly equal to the json chunk length, plus the header, it means there is no binary buffer chunk
-    if (length == (GLB_HEADER_BYTE_SIZE + jsonChunkLength))
+    if (length == (static_cast<uint64_t>(GLB_HEADER_BYTE_SIZE) + jsonChunkLength))
     {
         return;
     }
@@ -161,8 +162,8 @@ void GLBResourceReader::Init()
         throw InvalidGLTFException("Binary chunk should appear second");
     }
 
-    // Verify that the sum of the sizes of the chunks (plus the headers) matches the size of the file
-    const uint32_t chunkSizeSum = GLB_HEADER_BYTE_SIZE + jsonChunkLength + sizeof(bufferChunkLength) + GLB_CHUNK_TYPE_SIZE +  bufferChunkLength;
+    // Computed in 64-bit so the sum cannot wrap in 32-bit and spuriously match the file length.
+    const uint64_t chunkSizeSum = static_cast<uint64_t>(GLB_HEADER_BYTE_SIZE) + jsonChunkLength + sizeof(bufferChunkLength) + GLB_CHUNK_TYPE_SIZE +  bufferChunkLength;
 
     if (chunkSizeSum != length)
     {


### PR DESCRIPTION
GLBResourceReader::Init computed the GLB header/chunk size checks (GLB_HEADER_BYTE_SIZE + jsonChunkLength, and the component-chunk size sum) in 32-bit arithmetic. A maximal 32-bit JSON chunk length wraps the sum below the real file length, bypassing the "file length covers the header + JSON chunk" guard and letting ReadJson attempt an allocation of up to ~4 GB from a tiny file. Perform these additions in 64-bit (uint64_t) so the sums cannot wrap; the comparisons against the 32-bit file length are unchanged in behavior for all valid files.

ParseMaterial read baseColorFactor[0..3] and emissiveFactor[0..2] by fixed index without checking the parsed element count. When schema validation is disabled by the caller (SchemaFlags::DisableSchemaRoot), a short array leads to an out-of-bounds read past the parsed vector. Validate the element count (4 and 3 respectively) on the core parsing path, independent of schema flags, throwing InvalidGLTFException otherwise.

Adds regression tests: a GLB with a 0xFFFFFFFF JSON chunk length is now rejected, and short baseColorFactor/emissiveFactor arrays are rejected under SchemaFlags::DisableSchemaRoot.