### PR TITLE
Pin GitHub Actions to full-length commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -22,11 +22,11 @@ jobs:
             config: ${{ fromJson(inputs.configurations) }}
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
             submodules: 'true'
       - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v2.0.2
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
             cmake-version: ${{ inputs.cmake-version }}
       - name: CMake Configure

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,11 +22,11 @@ jobs:
             config: ${{ fromJson(inputs.configurations) }}
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
             submodules: 'true'
       - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v2.0.2
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
             cmake-version: ${{ inputs.cmake-version }}
       - name: CMake Configure
@@ -37,7 +37,7 @@ jobs:
       - name: Running Unit Tests
         run: ./GLTFSDK.Test --gtest_output=xml:GLTFSDK.Test.log
         working-directory: ./Built/Out/${{ matrix.platform }}/${{ matrix.config }}/GLTFSDK.Test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         name: "Upload test results"
         with:
             name: GLTFSDK.Test.Linux.${{ matrix.platform }}.${{ matrix.config }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,11 +22,11 @@ jobs:
             config: ${{ fromJson(inputs.configurations) }}
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
             submodules: 'true'
       - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v2.0.2
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
             cmake-version: ${{ inputs.cmake-version }}
       - name: CMake Configure
@@ -37,7 +37,7 @@ jobs:
       - name: Running Unit Tests
         run: ./GLTFSDK.Test --gtest_output=xml:GLTFSDK.Test.log
         working-directory: ./Built/Out/${{ matrix.platform }}/${{ matrix.config }}/GLTFSDK.Test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         name: "Upload test results"
         with:
             name: GLTFSDK.Test.MacOS.${{ matrix.platform }}.${{ matrix.config }}

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v2.0.2
+        uses: jwlawson/actions-setup-cmake@802fa1a2c4e212495c05bf94dba2704a92a472be # v2.0.2
         with:
             cmake-version: ${{ inputs.cmake-version }}
 
@@ -52,7 +52,7 @@ jobs:
           ASAN_OPTIONS: "detect_leaks=0:halt_on_error=1"
           UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         name: "Upload test results"
         if: always()
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -27,11 +27,11 @@ jobs:
             config: ${{ fromJson(inputs.configurations) }}
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
             submodules: 'true'
       - name: Setup CMake
-        uses: jwlawson/actions-setup-cmake@v2.2.0
+        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
         with:
             cmake-version: ${{ inputs.cmake-version }}
       - name: CMake Configure
@@ -43,7 +43,7 @@ jobs:
         if: ${{ (matrix.platform == 'x64') || (matrix.platform == 'Win32') }}
         run: .\GLTFSDK.Test.exe --gtest_output=xml:GLTFSDK.Test.log
         working-directory: ./Built/Out/windows_${{ matrix.platform }}\${{ matrix.config }}\GLTFSDK.Test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         name: "Upload test results"
         if: ${{ (matrix.platform == 'x64') || (matrix.platform == 'Win32') }}
         with:


### PR DESCRIPTION
## Summary

This PR pins GitHub Actions to full-length commit SHAs for improved security and reproducibility and adds a 7 day cooldown to Dependabot configuration for GitHub Actions. This work is described in more detail at https://aka.ms/action-pinning.

## Why?

Pinning actions to commit SHAs prevents supply-chain attacks where a tag could be moved to point to malicious code. This is a recommended security best practice per the [GitHub Actions security hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

This change mitigates the risk of tag retargeting to malicious code as seen in incidents like the [tj-actions/changed-files action compromise](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) or [codfish/semantic-release-action compromise](https://www.stepsecurity.io/blog/supply-chain-compromise-codfish-semantic-release-action) and improves the integrity and reproducibility of the CI/CD pipeline.

## What changed?

**Action pinning:** Third-party action references in `.github/workflows/` that used mutable tag-based references (e.g., `actions/checkout@v4`) have been updated to full-length commit SHAs with a version comment (e.g., `actions/checkout@<sha> # v4`) using the [pinact](https://github.com/suzuki-shunsuke/pinact) tool. References that were already pinned to a SHA, or that used immutable release tags, were left unchanged.

**Dependabot configuration:** `.github/dependabot.yml` has been updated to ensure a `github-actions` package-ecosystem section is present with a `cooldown` configuration (`default-days: 7`). This groups Dependabot PRs for GitHub Actions and enforces a minimum 7-day cooldown between updates. If the file did not exist, it was created. If a `github-actions` section already existed, only the `cooldown` block was added or its `default-days` value was increased to 7 if it was lower. The 7-day cooldown provides a window for the community to detect and report compromised releases before they are automatically proposed as updates, reducing exposure to supply-chain attacks via newly published malicious versions.

## Is this safe to merge?

Yes. The pinned SHAs correspond to the same commits that the existing tags pointed to. No behavioral changes are introduced. You can verify the pinned SHA value using the GitHub REST API (e.g., the commit hash for `actions/checkout@v7` can be found in the `sha` property in the JSON response for `GET https://api.github.com/repos/actions/checkout/commits/v7`).

## Additional Information

For more information, please see https://aka.ms/action-pinning
